### PR TITLE
Add custom GitHub actions for reuse across repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ The packages here are too experimental or too Grow-specific to be shared Woo-wid
 - [`/packages/js/storybook`](packages/js/storybook/README.md) - Storybook dependencies and basic scripts
 - [`/packages/js/tracking-jsdoc`](packages/js/tracking-jsdoc/README.md) - `jsdoc` plugin to document Tracking Events in markdown
 
+## GitHub actions
+- [`/github-actions/prepare-mysql`](github-actions/prepare-mysql) - Enable MySQL, handle authentication compatibility
+- [`/github-actions/prepare-node`](github-actions/prepare-node) - Set up Node.js with a specific version, load npm cache, install Node dependencies
+- [`/github-actions/prepare-php`](github-actions/prepare-php) - Set up PHP with a specific version and tools, load Composer cache, install Composer dependencies
+
 <p align="center">
 	<br/><br/>
 	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>

--- a/github-actions/prepare-mysql/README.md
+++ b/github-actions/prepare-mysql/README.md
@@ -1,0 +1,30 @@
+# Prepare MySQL in GitHub Actions
+
+This action provides the following functionality for GitHub Actions users:
+
+- Enable MySQL service
+- Handle the authentication compatibility for PHP 7.0-7.3
+- Log the version information
+
+## Usage
+
+See [action.yml](action.yml)
+
+#### Basic:
+
+```yaml
+jobs:
+  UnitTests:
+    name: Unit tests with database
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare MySQL
+        uses: woocommerce/grow/github-actions/prepare-mysql@github-actions
+
+      - name: Create database
+        run: mysql -e 'CREATE DATABASE IF NOT EXISTS wordpress_test;' -u root -proot
+```

--- a/github-actions/prepare-mysql/action.yml
+++ b/github-actions/prepare-mysql/action.yml
@@ -1,0 +1,21 @@
+name: Prepare MySQL
+description: Enable MySQL, handle authentication compatibility.
+
+runs:
+  using: composite
+  steps:
+    # Set up MySQL
+    - shell: bash
+      # MySQL 8.0 uses the `caching_sha2_password` authentication method by default.
+      # So here adds default_authentication_plugin=mysql_native_password to my.conf for PHP 7.0.x,
+      # and alters password with `mysql_native_password` authentication method
+      # to make PHP 7.3.x mysql client be able to create database connections.
+      run: |
+        echo "[mysqld]" | sudo tee -a /etc/mysql/my.cnf
+        echo "default_authentication_plugin=mysql_native_password" | sudo tee -a /etc/mysql/my.cnf
+        sudo systemctl start mysql.service
+        mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+
+    # Log information.
+    - shell: bash
+      run: mysql --version

--- a/github-actions/prepare-node/README.md
+++ b/github-actions/prepare-node/README.md
@@ -1,0 +1,84 @@
+# Prepare Node.js in GitHub Actions
+
+This action provides the following functionality for GitHub Actions users:
+
+- Set up Node.js with a specific version
+- Load caching npm dependencies
+- Run `npm ci` with or without the `--ignore-scripts` option
+- Log the version information of `node` and `npm`
+
+## Usage
+
+See [action.yml](action.yml)
+
+#### Basic:
+
+```yaml
+jobs:
+  Build:
+    name: Build bundle
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare node
+        uses: woocommerce/grow/github-actions/prepare-node@github-actions
+        with:
+          node-version: 16
+
+      - name: Build bundle
+        run: npm run build
+```
+
+Must specify either `node-version` or `node-version-file` option to set the version.
+
+[Supported version syntax](https://github.com/actions/setup-node/blob/v3/README.md#supported-version-syntax)
+
+#### Specify the node version via a file:
+
+```yaml
+steps:
+  - name: Checkout repository
+  - uses: actions/checkout@v3
+
+  - name: Prepare node
+    uses: woocommerce/grow/github-actions/prepare-node@github-actions
+    with:
+      node-version-file: ".nvmrc"
+```
+
+#### Skip the `npm ci`
+
+```yaml
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+
+  - name: Prepare node
+    uses: woocommerce/grow/github-actions/prepare-node@github-actions
+    with:
+      node-version: "lts/*"
+      install-deps: "no"
+
+  - name: My task
+    run: npm outdated
+```
+
+#### Run `npm ci` with the `--ignore-scripts` option
+
+```yaml
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+
+  - name: Prepare node
+    uses: woocommerce/grow/github-actions/prepare-node@github-actions
+    with:
+      node-version: "latest"
+      ignore-scripts: "no"
+
+  - name: My task
+    run: npm run lint:js
+```

--- a/github-actions/prepare-node/action.yml
+++ b/github-actions/prepare-node/action.yml
@@ -1,0 +1,53 @@
+name: Prepare Node.js
+description: Set up Node.js with a specific version, load npm cache, install Node dependencies.
+
+inputs:
+  node-version:
+    description: "Specify Node.js version. For example: 16, 14.19.1, 14.19, lts/fermium, lts/*, latest, current"
+    default: ""
+
+  node-version-file:
+    description: "Specify Node.js version via a file. For example: .nvmrc"
+    default: ""
+
+  install-deps:
+    description: Whether to run `npm ci`. "yes" by default. Set "no" to skip.
+    required: false
+    default: "yes"
+
+  ignore-scripts:
+    description: Whether to run `npm ci` with --ignore-scripts. "yes" by default.
+    required: false
+    default: "yes"
+
+runs:
+  using: composite
+  steps:
+    # Setup node version and caching.
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+        cache: "npm"
+
+    # Log information.
+    - shell: bash
+      run: |
+        node --version
+        npm --version
+
+    # Install node dependencies.
+    - shell: bash
+      # `actions/setup-node` should update npm cache directory if `package-lock` has changed.
+      run: |
+        INSTALL_DEPS="${{ inputs.install-deps }}"
+        IGNORE_SCRIPTS="${{ inputs.ignore-scripts }}"
+
+        COLOR_INFO="\033[38;5;39m"
+        COLOR_END="\033[0m"
+
+        if [ $INSTALL_DEPS = "yes" ]; then
+          npm ci `if [ $IGNORE_SCRIPTS = "yes" ]; then printf %s "--ignore-scripts"; fi`
+        else
+          echo -e "${COLOR_INFO}Skip npm ci${COLOR_END}"
+        fi

--- a/github-actions/prepare-php/README.md
+++ b/github-actions/prepare-php/README.md
@@ -1,0 +1,99 @@
+# Prepare PHP in GitHub Actions
+
+This action provides the following functionality for GitHub Actions users:
+
+- Set up PHP with a specific version
+- Set up tools like `cs2pr`, `wp-cli`, etc
+- Set up coverage driver
+- Load caching Composer dependencies
+- Run `composer install --prefer-dist --no-interaction`
+- Log the version information of `php` and `composer`
+
+## Usage
+
+See [action.yml](action.yml)
+
+#### Basic:
+
+```yaml
+jobs:
+  UnitTests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/github-actions/prepare-php@github-actions
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit
+```
+
+#### Specify the PHP version:
+
+```yaml
+steps:
+  - name: Checkout repository
+  - uses: actions/checkout@v3
+
+  - name: Prepare PHP
+    uses: woocommerce/grow/github-actions/prepare-php@github-actions
+    with:
+      php-version: 16
+```
+
+#### Set up with tools
+
+```yaml
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+
+  - name: Prepare PHP
+    uses: woocommerce/grow/github-actions/prepare-php@github-actions
+    with:
+      tools: cs2pr
+
+  - name: Coding standards
+    run: vendor/bin/phpcs ./* -q --report=checkstyle | cs2pr
+```
+
+To use Composer v1, set this parameter with `composer:v1`
+
+[Full list of support tools](https://github.com/shivammathur/setup-php/blob/v2/README.md#wrench-tools-support)
+
+#### Set up coverage driver
+
+```yaml
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+
+  - name: Prepare PHP
+    uses: woocommerce/grow/github-actions/prepare-php@github-actions
+    with:
+      coverage: xdebug
+```
+
+The `coverage` is `"none"` by default to disable both `Xdebug` and `PCOV`.
+
+[Supported coverage drivers](https://github.com/shivammathur/setup-php/blob/v2/README.md#signal_strength-coverage-support)
+
+#### Skip the `composer install`
+
+```yaml
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+
+  - name: Prepare PHP
+    uses: woocommerce/grow/github-actions/prepare-php@github-actions
+    with:
+      install-deps: "no"
+
+  - name: My task
+    run: composer update --prefer-dist --no-interaction
+```

--- a/github-actions/prepare-php/action.yml
+++ b/github-actions/prepare-php/action.yml
@@ -1,0 +1,73 @@
+name: Prepare PHP
+description: Set up PHP with a specific version and tools, load Composer cache, install Composer dependencies.
+
+inputs:
+  php-version:
+    description: Specify PHP version. "7.4" by default.
+    required: false
+    default: "7.4"
+
+  coverage:
+    description: >
+      Specify the coverage parameter of shivammathur/setup-php@v2.
+      "none" by default to disable both Xdebug and PCOV.
+    required: false
+    default: "none"
+
+  tools:
+    description: >
+      Specify the tools parameter of shivammathur/setup-php@v2.
+      It accepts multiple tools separated by commas. For example: cs2pr, php-cs-fixer, wp-cli
+      Composer v2 is a built-in tool by default, so it's no need to specify additional.
+      To use Composer v1, set this parameter with composer:v1
+      Full list of support tools: https://github.com/shivammathur/setup-php#wrench-tools-support
+    required: false
+
+  install-deps:
+    description: Whether to run `composer install`. "yes" by default. Set "no" to skip.
+    required: false
+    default: "yes"
+
+runs:
+  using: composite
+  steps:
+    # Set up PHP and tools.
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        coverage: ${{ inputs.coverage }}
+        tools: ${{ inputs.tools }}
+
+    # Log information.
+    - shell: bash
+      run: |
+        php --version
+        composer --version
+
+    # Get Composer cache directory.
+    - shell: bash
+      id: composer-cache-config
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    # Set up Composer caching.
+    - uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache-config.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    # Install Composer dependencies.
+    - shell: bash
+      run: |
+        INSTALL_DEPS="${{ inputs.install-deps }}"
+        COMPOSER_VER=$(composer --version | awk '{ print $3 }')
+
+        COLOR_INFO="\033[38;5;39m"
+        COLOR_END="\033[0m"
+
+        if [ $INSTALL_DEPS = "yes" ]; then
+          composer install --prefer-dist --no-interaction `if [[ $COMPOSER_VER == 1.* ]]; then printf %s "--no-suggest"; fi`
+          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+        else
+          echo -e "${COLOR_INFO}Skip composer install${COLOR_END}"
+        fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's phase 1 of the migration plan in this comment - pb0Spc-2DL-p2#comment-5753.

Add three custom GitHub actions for reuse across repositories.

### Detailed test instructions:

Go to the Files changed and Check tabs of the RP 1126-gh-woocommerce/automatewoo to see how these custom actions are used.

### Additional details:

About the custom composite action: https://docs.github.com/en/actions/creating-actions/creating-a-composite-action

### Changelog entry

> Add - Custom GitHub actions for reuse across repositories.