### PR TITLE
Forward args & source directory to `-jsdoc` binary.

### DIFF
--- a/packages/js/jsdoc/README.md
+++ b/packages/js/jsdoc/README.md
@@ -25,13 +25,13 @@ A bundle of commonly used JSDoc plugins and a command to glue as much as possibl
          "jsdoc-plugin-intersection"
       ],
       "typescript": {
-         "moduleRoot": "js/src"
+         "moduleRoot": "./js/src"
       }
    }
    ```
 4. Generate the docs
    ```sh
-   woocommerce-grow-jsdoc
+   woocommerce-grow-jsdoc ./js/src
    ```
 
 ## Included plugins
@@ -71,7 +71,7 @@ To mitigate that use the `jsdoc-plugin-typescript` plugin to skip those.
     "jsdoc-plugin-typescript"
   ],
   "typescript": {
-    "moduleRoot": "assets/source" // Path to your module's root directory.
+    "moduleRoot": "./js/src" // Path to your module's root directory.
   }
   // …
 ```

--- a/packages/js/jsdoc/bin/jsdoc.mjs
+++ b/packages/js/jsdoc/bin/jsdoc.mjs
@@ -7,4 +7,5 @@ import path from 'path';
 
 process.env.PATH += ( path.delimiter + path.join( process.cwd(), 'node_modules', '.bin') );
 
-shell.exec("jsdoc -r ./js/src -c .jsdocrc.json -t woocommerce-grow-tracking-jsdoc");
+const args = process.argv.slice( 2 );
+shell.exec( 'jsdoc -r -c .jsdocrc.json -t woocommerce-grow-tracking-jsdoc ' + args.join( ' ' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Allows extensions to keep JS source in different folders, like GLA vs. Pinterest


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow https://github.com/woocommerce/pinterest-for-woocommerce/pull/475
2. Follow https://github.com/woocommerce/google-listings-and-ads/pull/1521


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - Forward args & source directory to `-jsdoc` binary
