### PR TITLE
Add a GitHub action for adding branch type labels

### DIFF
--- a/packages/js/github-actions/README.md
+++ b/packages/js/github-actions/README.md
@@ -6,6 +6,7 @@ Custom GitHub actions that help to composite GitHub workflows across the repos m
 
 ## Actions list
 
+- [`branch-label`](actions/branch-label) - Set PR labels according to the branch name
 - [`get-release-notes`](actions/get-release-notes) - Get release notes via GitHub, infer the next version and tag
 - [`phpcs-diff`](actions/phpcs-diff) - Run PHPCS to the changed lines of code, set error annotations to a pull request
 - [`prepare-mysql`](actions/prepare-mysql) - Enable MySQL, handle authentication compatibility

--- a/packages/js/github-actions/actions/branch-label/README.md
+++ b/packages/js/github-actions/actions/branch-label/README.md
@@ -2,6 +2,13 @@
 
 This action sets PR's `type: *` & `changelog: *` labels according to the branch name convention.
 
+Branch names starting
+- `(breaking|add|update|fix|tweak|doc)/` get `changelog: *`
+- `release/` get `changelog: none`
+- `add/` get also `type: enhancement`
+- `fix/` get also `type: bug`
+- `doc/` get also `type: documentation`
+
 ## Usage
 
 See [action.yml](action.yml)

--- a/packages/js/github-actions/actions/branch-label/README.md
+++ b/packages/js/github-actions/actions/branch-label/README.md
@@ -1,0 +1,21 @@
+# Branchname to Changelog label
+
+This action sets PR's `type: *` & `changelog: *` labels according to the branch name convention.
+
+## Usage
+
+See [action.yml](action.yml)
+
+#### Basic:
+
+```yaml
+on:
+  pull_request:
+    types: opened
+jobs:
+  SetLabels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Labels
+        uses: woocommerce/grow/github-actions/branch-label@add/label-action
+```

--- a/packages/js/github-actions/actions/branch-label/README.md
+++ b/packages/js/github-actions/actions/branch-label/README.md
@@ -24,5 +24,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/github-actions/branch-label@add/label-action
+        uses: woocommerce/grow/branch-label@actions-v1
 ```

--- a/packages/js/github-actions/actions/branch-label/action.yml
+++ b/packages/js/github-actions/actions/branch-label/action.yml
@@ -1,0 +1,29 @@
+name: Branch Type to Label
+description: Set PR labels according to the branch name.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v2
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'add/') }}
+      with:
+        labels: |
+          type: enhancement
+          changelog: add
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'fix/') }}
+      with:
+        labels: |
+          type: bug
+          changelog: fix
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'update/') || startsWith(github.head_ref, 'remove/') }}
+      with:
+        labels: |
+          changelog: update
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'tweak/') || startsWith(github.head_ref, 'dev/') }}
+      with:
+        labels: |
+          changelog: tweak

--- a/packages/js/github-actions/actions/branch-label/action.yml
+++ b/packages/js/github-actions/actions/branch-label/action.yml
@@ -6,11 +6,21 @@ runs:
   steps:
     - uses: actions/checkout@v2
     - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'breaking/') }}
+      with:
+        labels: |
+          changelog: breaking
+    - uses: actions-ecosystem/action-add-labels@v1
       if: ${{ startsWith(github.head_ref, 'add/') }}
       with:
         labels: |
           type: enhancement
           changelog: add
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'update/') }}
+      with:
+        labels: |
+          changelog: update
     - uses: actions-ecosystem/action-add-labels@v1
       if: ${{ startsWith(github.head_ref, 'fix/') }}
       with:
@@ -18,15 +28,16 @@ runs:
           type: bug
           changelog: fix
     - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'update/') || startsWith(github.head_ref, 'remove/') }}
-      with:
-        labels: |
-          changelog: update
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'tweak/') || startsWith(github.head_ref, 'dev/') }}
+      if: ${{ startsWith(github.head_ref, 'tweak/') }}
       with:
         labels: |
           changelog: tweak
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'doc/') }}
+      with:
+        labels: |
+          changelog: doc
+          type: documentation
     - uses: actions-ecosystem/action-add-labels@v1
       if: ${{ startsWith(github.head_ref, 'release/') }}
       with:

--- a/packages/js/github-actions/actions/branch-label/action.yml
+++ b/packages/js/github-actions/actions/branch-label/action.yml
@@ -27,3 +27,8 @@ runs:
       with:
         labels: |
           changelog: tweak
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'release/') }}
+      with:
+        labels: |
+          changelog: none

--- a/packages/js/github-actions/actions/branch-label/action.yml
+++ b/packages/js/github-actions/actions/branch-label/action.yml
@@ -4,7 +4,6 @@ description: Set PR labels according to the branch name.
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v2
     - uses: actions-ecosystem/action-add-labels@v1
       if: ${{ startsWith(github.head_ref, 'breaking/') }}
       with:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Sets `type: *` and `changelog: *` labels to a created PR, according to a branch name convention

It uses actions-ecosystem/action-add-labels to keep it consistent with 
https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/update-feedback-labels.yml

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Pick a test repo
2. Follow the instructions in https://github.com/woocommerce/grow/compare/github-actions...add/label-action?expand=1#diff-ffef87c73e2a2202c94315b3bf7f301382b60802da7cb2db0e12935d936f8549


### Additional details:

1. This PR does follow the convention proposed in https://github.com/woocommerce/google-listings-and-ads/pull/1565. Therefore changes and unifies the set of branch prefixes and changelog entry types.
2. The flow proposed here, works well for regular single-package repos. However, it doesn't play well for monorepos, like this (`/grow`) one. I wonder how would we like to infer the package name to be set for [`[{package-name}] changelog: {type}`](https://github.com/woocommerce/grow/pull/18)? should we use branch names, like `actions/fix/123-slug`? Then `actions` or `github-actions` to follow the package name? Or maybe have another action to check the files modified, and set `package: storybook`, then let this action take that into consideration?
 @eason9487  

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

>
