### PR TITLE
Add a new custom action `phpcs-diff` to run PHPCS to the changed lines of code in a PR

### DIFF
--- a/packages/js/github-actions/README.md
+++ b/packages/js/github-actions/README.md
@@ -7,6 +7,7 @@ Custom GitHub actions that help to composite GitHub workflows across the repos m
 ## Actions list
 
 - [`get-release-notes`](actions/get-release-notes) - Get release notes via GitHub, infer the next version and tag
+- [`phpcs-diff`](actions/phpcs-diff) - Run PHPCS to the changed lines of code, set error annotations to a pull request
 - [`prepare-mysql`](actions/prepare-mysql) - Enable MySQL, handle authentication compatibility
 - [`prepare-node`](actions/prepare-node) - Set up Node.js with a specific version, load npm cache, install Node dependencies
 - [`prepare-php`](actions/prepare-php) - Set up PHP with a specific version and tools, load Composer cache, install Composer dependencies

--- a/packages/js/github-actions/actions/phpcs-diff/README.md
+++ b/packages/js/github-actions/actions/phpcs-diff/README.md
@@ -1,0 +1,37 @@
+# Run PHPCS Diff in GitHub Actions
+
+This action provides the following functionality for GitHub Actions users:
+
+- Run PHPCS to the changed lines of code in a pull request.
+- Set error annotations to a pull request.
+
+## Prerequisites
+
+Install required packages: `dealerdirect/phpcodesniffer-composer-installer` and `exussum12/coverage-checker`.
+
+- `composer require --dev dealerdirect/phpcodesniffer-composer-installer:^v0.7 exussum12/coverage-checker:^1.0`
+
+## Usage
+
+See [action.yml](action.yml)
+
+When a repository is not maintained initially with PHPCS, it could get a lot of errors if introduced. This action allows PHPCS to run only for the changed lines of code in a PR, enabling repository maintenance to introduce PHPCS and then progressively adjust the codebase.
+
+#### Basic:
+
+```yaml
+name: PHP Coding Standards - Diff
+
+on:
+  pull_request:
+    paths:
+      - "**.php"
+
+jobs:
+  CodingStandardsDiff:
+    name: PHP coding standards - diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run PHPCS to changed lines of code
+        uses: woocommerce/grow/phpcs-diff@actions-v1
+```

--- a/packages/js/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/js/github-actions/actions/phpcs-diff/action.yml
@@ -1,0 +1,32 @@
+name: PHPCS Diff
+description: Run PHPCS to the changed lines of code, set error annotations to a pull request.
+
+runs:
+  using: composite
+  steps:
+    # Checkout repository.
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    # Set up PHP and tools.
+    - uses: woocommerce/grow/prepare-php@actions-v1-pre
+
+    #Log information
+    - shell: bash
+      run: |
+        vendor/bin/phpcs -i
+        vendor/bin/diffFilter -v
+
+    # Run PHPCS with diffFilter in the coverageChecker.
+    - shell: bash
+      run: |
+        vendor/bin/diffFilter --phpcsStrict <(git diff HEAD^...HEAD) <(vendor/bin/phpcs ./* -q --report=json) --report=phpcs 0 > /tmp/phpcs-diff.json
+        cd "${{ github.action_path }}"
+        node annotate-phpcs-report.js /tmp/phpcs-diff.json
+        cd -
+
+        TOTAL_ERRORS=$(jq ".totals.errors" /tmp/phpcs-diff.json)
+        if [ "$TOTAL_ERRORS" != "0" ]; then
+          exit 1
+        fi

--- a/packages/js/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/js/github-actions/actions/phpcs-diff/action.yml
@@ -10,7 +10,7 @@ runs:
         fetch-depth: 2
 
     # Set up PHP and tools.
-    - uses: woocommerce/grow/prepare-php@actions-v1-pre
+    - uses: woocommerce/grow/prepare-php@actions-v1
 
     #Log information
     - shell: bash

--- a/packages/js/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/js/github-actions/actions/phpcs-diff/action.yml
@@ -20,6 +20,10 @@ runs:
 
     # Run PHPCS with diffFilter in the coverageChecker.
     - shell: bash
+      # When creating a pull request on GitHub, it will create a merge commit locally based on
+      # the `head` and `base` branches of the PR. It's the same in GitHub Actions, when triggering
+      # a workflow to a pull request, it uses the revision of a merge commit to run the workflow
+      # as well. Therefore, `git diff HEAD^...HEAD` includes all diffs of a PR.
       run: |
         vendor/bin/diffFilter --phpcsStrict <(git diff HEAD^...HEAD) <(vendor/bin/phpcs ./* -q --report=json) --report=phpcs 0 > /tmp/phpcs-diff.json
         cd "${{ github.action_path }}"

--- a/packages/js/github-actions/actions/phpcs-diff/src/annotate-phpcs-report.js
+++ b/packages/js/github-actions/actions/phpcs-diff/src/annotate-phpcs-report.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import fs from 'fs';
+import { argv } from 'node:process';
+
+/**
+ * Internal dependencies
+ */
+import annotateByWorkflowCommand from '../../../utils/annotate-by-workflow-command.js';
+import handleActionErrors from '../../../utils/handle-action-errors.js';
+
+function toAnnotations( reportFiles ) {
+	const entries = Object.entries( reportFiles );
+	const annotations = [];
+
+	entries.forEach( ( [ filePath, metadata ] ) => {
+		metadata.messages.forEach( ( { line, message } ) => {
+			// The `coverageChecker` package doesn't output warnings by default,
+			// and warnings are treated as errors in its strict mode.
+			// So all messages can only be transformed as error annotations here.
+			annotations.push( {
+				command: 'error',
+				filePath: `./${ filePath }`,
+				line,
+				message,
+			} );
+		} );
+	} );
+
+	return annotations;
+}
+
+/**
+ * Sets errors in the PHPCS as annotations onto GitHub Actions.
+ * Pass the PHPCS report in JSON format with the first argument:
+ * `node annotate-phpcs-report.js path-to-report.json`.
+ */
+async function annotatePhpcsReport() {
+	const reportFilePath = argv[ 2 ];
+	const jsonReport = fs.readFileSync( reportFilePath, 'utf8' );
+	const report = JSON.parse( jsonReport );
+	const annotations = toAnnotations( report.files );
+
+	annotateByWorkflowCommand( annotations );
+}
+
+// Start running this action.
+annotatePhpcsReport().catch( handleActionErrors );

--- a/packages/js/github-actions/package.json
+++ b/packages/js/github-actions/package.json
@@ -4,9 +4,11 @@
   "description": "GitHub JavaScript actions for a WooCommerce plugin repo by Grow Team.",
   "type": "module",
   "scripts": {
-    "build": "npm run build:get-release-notes && npm run build:update-version-tags",
+    "build": "npm run build:get-release-notes && npm run build:phpcs-diff && npm run build:update-version-tags",
     "build:get-release-notes": "npx @vercel/ncc build ./actions/get-release-notes/src/get-release-notes.js -o ./actions/get-release-notes",
     "postbuild:get-release-notes": "mv ./actions/get-release-notes/index.js ./actions/get-release-notes/get-release-notes.js",
+    "build:phpcs-diff": "npx @vercel/ncc build ./actions/phpcs-diff/src/annotate-phpcs-report.js -o ./actions/phpcs-diff",
+    "postbuild:phpcs-diff": "mv ./actions/phpcs-diff/index.js ./actions/phpcs-diff/annotate-phpcs-report.js",
     "build:update-version-tags": "npx @vercel/ncc build ./actions/update-version-tags/src/update-version-tags.js -o ./actions/update-version-tags",
     "postbuild:update-version-tags": "mv ./actions/update-version-tags/index.js ./actions/update-version-tags/update-version-tags.js"
   },

--- a/packages/js/github-actions/utils/annotate-by-workflow-command.js
+++ b/packages/js/github-actions/utils/annotate-by-workflow-command.js
@@ -1,0 +1,50 @@
+/**
+ * @typedef {Object} Annotation
+ * @property {string} command Annotation command name.
+ * @property {string} [message] Annotation message.
+ * @property {string} [filePath] Path to the associated file.
+ * @property {string} [line] Line number of the associated file, starting at 1.
+ * @property {string} [endLine] End line number of the associated file.
+ * @property {string} [column] Column number of the associated file, starting at 1.
+ * @property {string} [endColumn] End column number of the associated file.
+ */
+
+function toAnnotationCommand( annotation ) {
+	const regex = /([ ,]?\w+=)?\{(\w+)\}/g;
+	const template =
+		'::{command} file={filePath},line={line},endLine={endLine},col={column},endColumn={endColumn}::{message}';
+
+	return template.replace( regex, ( _, paramGroup = '', key ) => {
+		if ( annotation.hasOwnProperty( key ) ) {
+			return paramGroup + annotation[ key ];
+		}
+		return '';
+	} );
+}
+
+/**
+ * Sets annotations onto GitHub Actions by workflow commands.
+ *
+ * Commonly used workflow commands:
+ * - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+ * - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message
+ * - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+ *
+ * @param  {Array<Annotation>} annotations Annotations to be handled.
+ */
+export default function annotateByWorkflowCommand( annotations ) {
+	if ( annotations.length === 0 ) {
+		return;
+	}
+
+	// Wrap the command outputs into an expandable group in the GitHub Actions.
+	const groupingAnnotations = [
+		{ command: 'group', message: 'Annotation commands' },
+		...annotations,
+		{ command: 'endgroup' },
+	];
+
+	groupingAnnotations
+		.map( toAnnotationCommand )
+		.forEach( ( command ) => console.log( command ) ); // eslint-disable-line no-console
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a part of the progressively adding PHPCS task in this project - pb0Spc-2DL-p2.

- Add a new util `annotateByWorkflowCommand` to set annotations by workflow commands of GitHub Actions.
- Add a new custom action `phpcs-diff` to run PHPCS to the changed lines of code in a PR.

Before merging this PR:

- [x] Remove the `actions-v1-pre` release and related tags from this repo.
- [x] Change the version of prepare-php from `actions-v1-pre` to `actions-v1`.
   - https://github.com/woocommerce/grow/blob/b197a7154872906a0050fb55b036bf01ddd397ee/packages/js/github-actions/actions/phpcs-diff/action.yml#L13

### Detailed test instructions:

Go to the Files changed and Check tabs of the RP 458-gh-woocommerce-points-and-rewards to see how this custom action is used. The following is the group of annotation commands Run in the "PHPCS to changed lines of code" job captured from that PR's checks.

![image](https://user-images.githubusercontent.com/17420811/174787485-8debe1c3-1d1d-4118-a3a9-7585835d8b88.png)
