### PR TITLE
Tweak the `update-version-tags` action and the `github-actions-release` workflow

### DIFF
--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -54,7 +54,7 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git rm -r .
-          git commit -q -m "Build the ${{ github.event.release.tag_name }} release build of GitHub actions."
+          git commit -q -m "Create the ${{ github.event.release.tag_name }} release build for the \`github-actions\` package."
           git checkout HEAD^ -- ./packages/js/github-actions/actions
           git restore --staged .
           echo "/packages/js/github-actions/actions/*/src" > .gitignore

--- a/packages/js/github-actions/actions/update-version-tags/action.yml
+++ b/packages/js/github-actions/actions/update-version-tags/action.yml
@@ -4,6 +4,7 @@ description: Update version tags.
 inputs:
   repo-token:
     description: The GITHUB_TOKEN secret.
+    required: true
 
   sha:
     description: The SHA1 of commit to set version tags. By default, uses the release branch or commit.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Adjust the commit wording of the release builds to make it clearer.
- The `repo-token` input in `update-version-tags` action is required. Add the missing `required: true` config for it.

### Detailed test instructions:

N/A
