### PR TITLE
Add escaped outputs `release-notes-shell` and `release-changelog-shell` for the get-release-notes action

### DIFF
--- a/packages/js/github-actions/actions/get-release-notes/README.md
+++ b/packages/js/github-actions/actions/get-release-notes/README.md
@@ -33,9 +33,11 @@ on:
 
       - name: Echo release notes
         run: |
-          echo "${{ steps.get-notes.outputs.release-notes }}"
-          echo "${{ steps.get-notes.outputs.release-changelog }}"
+          echo '${{ steps.get-notes.outputs.release-notes-shell }}'
+          echo '${{ steps.get-notes.outputs.release-changelog-shell }}'
 ```
+
+:pushpin: Please note that when using release notes in the shell, always use the output with `-shell` suffix and wrap it in single quotes to avoid special characters that may cause problems.
 
 #### Matching version level keywords to infer the next version and tag:
 
@@ -96,8 +98,8 @@ jobs:
 
       - name: Echo release notes
         run: |
-          echo "${{ steps.get-notes.outputs.release-notes }}"
-          echo "${{ steps.get-notes.outputs.release-changelog }}"
+          echo '${{ steps.get-notes.outputs.release-notes-shell }}'
+          echo '${{ steps.get-notes.outputs.release-changelog-shell }}'
           echo "${{ steps.get-notes.outputs.next-version }}"
           echo "${{ steps.get-notes.outputs.next-tag }}"
 ```
@@ -147,12 +149,14 @@ jobs:
         run: |
           TODAY=$(date '+%Y-%m-%d')
           NEXT_VER="${{ steps.get-notes.outputs.next-version }}"
-          CHANGELOG="${{ steps.get-notes.outputs.release-changelog }}"
+          CHANGELOG='${{ steps.get-notes.outputs.release-changelog-shell }}'
+
           printf "## ${TODAY} (${NEXT_VER})\n${CHANGELOG}\n\n%s\n" "$(cat CHANGELOG.md)" > CHANGELOG.md
           jq ".version=\"${NEXT_VER}\"" package.json > package.json.tmp
           mv package.json.tmp package.json
           jq ".version=\"${NEXT_VER}\"" package-lock.json > package-lock.json.tmp
           mv package-lock.json.tmp package-lock.json
+
           git config user.name github-actions
           git config user.email github-actions@users.noreply.github.com
           git add CHANGELOG.md

--- a/packages/js/github-actions/actions/get-release-notes/action.yml
+++ b/packages/js/github-actions/actions/get-release-notes/action.yml
@@ -53,8 +53,14 @@ outputs:
   release-notes:
     description: The content of release notes.
 
+  release-notes-shell:
+    description: The escaped "release-notes" for use in the shell.
+
   release-changelog:
     description: The changelog part in release notes.
+
+  release-changelog-shell:
+    description: The escaped "release-changelog" for use in the shell.
 
   next-version:
     description: The next version inferred via the release notes. For example, 2.0.0, 1.5.0 or 1.4.8.

--- a/packages/js/github-actions/actions/get-release-notes/src/get-release-notes.js
+++ b/packages/js/github-actions/actions/get-release-notes/src/get-release-notes.js
@@ -30,6 +30,10 @@ function parseChangelog( notesContent ) {
 	return '';
 }
 
+function escapeSingleQuote( text ) {
+	return text.replace( /'/g, `'"'"'` );
+}
+
 function setOutput( key, value ) {
 	core.info( `==> Output "${ key }":\n${ value }` );
 	core.setOutput( key, value );
@@ -97,7 +101,9 @@ async function getReleaseNotes() {
 
 	// Output results
 	setOutput( 'release-notes', notesContent );
+	setOutput( 'release-notes-shell', escapeSingleQuote( notesContent ) );
 	setOutput( 'release-changelog', changelog );
+	setOutput( 'release-changelog-shell', escapeSingleQuote( changelog ) );
 	setOutput( 'next-version', nextVersion );
 	setOutput( 'next-tag', nextTag );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Using the `release-notes`or `release-changelog` outputs of get-release-notes action with double quotes in the shell may have problems. Such as there are backticks in a PR title, it would be a calling to a shell command:

```sh
LOG="${{ steps.get-notes.outputs.release-changelog }}"
```

![2022-06-24 18 43 07](https://user-images.githubusercontent.com/17420811/175525183-e43a4bbe-b3c6-4446-9c88-9ae7504fea9e.png)

And using single quotes in the shell may have problems when there are single quotes in a PR title:

```sh
LOG='${{ steps.get-notes.outputs.release-changelog }}'
```

This PR adds two outputs `release-notes-shell` and `release-changelog-shell`, which are escaped the single quotes, for use in the shell.

### Detailed test instructions:

See the test instructions in #21.