### PR TITLE
Fix the issue that unescaped chars may break the release preparation of `github-actions` package

### DIFF
--- a/.github/workflows/github-actions-prepare-release.yml
+++ b/.github/workflows/github-actions-prepare-release.yml
@@ -60,17 +60,21 @@ jobs:
         # https://api.github.com/users/github-actions%5Bbot%5D
         run: |
           cd ./packages/js/github-actions
+
           TODAY=$(date '+%Y-%m-%d')
           NEXT_VER="${{ steps.get-notes.outputs.next-version }}"
-          CHANGELOG="${{ steps.get-notes.outputs.release-changelog }}"
+          CHANGELOG='${{ steps.get-notes.outputs.release-changelog-shell }}'
           CHANGELOG=$(echo "$CHANGELOG" | sed -E 's/\.? by @[^ ]+ in (https:\/\/github\.com\/.+)/. (\1)/')
+
           sed -i "/# Changelog/r"<(
             printf "\n## ${TODAY} (${NEXT_VER})\n${CHANGELOG}\n"
           ) CHANGELOG.md
+
           jq ".version=\"${NEXT_VER}\"" package.json > package.json.tmp
           mv package.json.tmp package.json
           jq ".version=\"${NEXT_VER}\"" package-lock.json > package-lock.json.tmp
           mv package-lock.json.tmp package-lock.json
+
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add CHANGELOG.md


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I encountered problems when releasing `actions-v1.0.0` since there are backticks ``` ` ``` in some PR titles such as #18.
I temporarily changed the PR title at that time. This PR fixes the problem with the new output added in #20.

### Detailed test instructions:

There is no merged and unreleased PR that can be used to test. I reproduced the problem and created another demo to show this fix in a forked repo.


1. Go to the workflow runs in the forked repo to check the reproduced problem.
   - https://github.com/eason9487/grow/runs/7040144339?check_suite_focus=true#step:6:5
      ![2022-06-24 18 43 07](https://user-images.githubusercontent.com/17420811/175525183-e43a4bbe-b3c6-4446-9c88-9ae7504fea9e.png)
2. Go to the workflow runs in the forked repo to check the fix.
   - https://github.com/eason9487/grow/runs/7040395059?check_suite_focus=true#step:6:6
      ![2022-06-24 19 05 06](https://user-images.githubusercontent.com/17420811/175525693-367df0dc-78e2-4e39-b6bd-c10b658bfc1b.png)
3. Check if the committed changelog has the same title as the released PR.
   - https://github.com/eason9487/grow/commit/2d605b4bdcad223e0998e15f8b775c59ecc150e6
      ![image](https://user-images.githubusercontent.com/17420811/175527763-8f9d7f9d-cd7c-4329-b85a-e15a7260e575.png)
