### PR TITLE
Fix the JSON parse error when manually releasing the `github-actions` package

### DIFF
--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           TAG_NAME="${{ github.event.release.tag_name }}"
           if [ "$TAG_NAME" = '' ]; then
-            TAG_NAME="${{ fromJSON(needs.Setup.outputs.release).tag_name }}"
+            TAG_NAME="${{ fromJSON(needs.Setup.outputs.release || '{}').tag_name }}"
           fi
           echo "::set-output name=tag_name::${TAG_NAME}"
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add tag name fallback to prevent parse error when manually releasing the `github-actions` package.

### Detailed test instructions:

Go to the [test release](https://github.com/woocommerce/grow/runs/7231865349?check_suite_focus=true#step:2:4) to see the composed bash script for resolving the release tag name.

![image](https://user-images.githubusercontent.com/17420811/177758522-24910c9a-72b4-4d1e-a422-0782d177c195.png)
