### PR TITLE
Add "php-version" input to the phpcs-diff action for specifying PHP version

### DIFF
--- a/packages/js/github-actions/actions/phpcs-diff/README.md
+++ b/packages/js/github-actions/actions/phpcs-diff/README.md
@@ -35,3 +35,13 @@ jobs:
       - name: Run PHPCS to changed lines of code
         uses: woocommerce/grow/phpcs-diff@actions-v1
 ```
+
+#### Specify the PHP version:
+
+```yaml
+steps:
+  - name: Run PHPCS to changed lines of code
+    uses: woocommerce/grow/phpcs-diff@actions-v1
+    with:
+      php-version: 16
+```

--- a/packages/js/github-actions/actions/phpcs-diff/README.md
+++ b/packages/js/github-actions/actions/phpcs-diff/README.md
@@ -43,5 +43,5 @@ steps:
   - name: Run PHPCS to changed lines of code
     uses: woocommerce/grow/phpcs-diff@actions-v1
     with:
-      php-version: 16
+      php-version: 8.1
 ```

--- a/packages/js/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/js/github-actions/actions/phpcs-diff/action.yml
@@ -1,6 +1,12 @@
 name: PHPCS Diff
 description: Run PHPCS to the changed lines of code, set error annotations to a pull request.
 
+inputs:
+  php-version:
+    description: Specify PHP version. "7.4" by default.
+    required: false
+    default: "7.4"
+
 runs:
   using: composite
   steps:
@@ -9,8 +15,10 @@ runs:
       with:
         fetch-depth: 2
 
-    # Set up PHP and tools.
+    # Set up PHP.
     - uses: woocommerce/grow/prepare-php@actions-v1
+      with:
+        php-version: ${{ inputs.php-version }}
 
     #Log information
     - shell: bash

--- a/packages/js/github-actions/actions/prepare-php/README.md
+++ b/packages/js/github-actions/actions/prepare-php/README.md
@@ -42,7 +42,7 @@ steps:
   - name: Prepare PHP
     uses: woocommerce/grow/prepare-php@actions-v1
     with:
-      php-version: 16
+      php-version: 8.1
 ```
 
 #### Set up with tools


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add "php-version" input to the `phpcs-diff.yml` action for specifying PHP version.

Checklist before merging:

- [x] Delete `actions-v1.0.0-pre` release.
- [x] Delete `actions-v1.0.0-pre`, `actions-v1.0-pre`, and `actions-v1-pre` tags.

### Detailed test instructions:

1. View the [check result](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/2628819359) of a caller repo before adding the input. There are warnings of `Unexpected input(s) 'php-version'`.
   ![image](https://user-images.githubusercontent.com/17420811/177759493-ffe0adb8-730e-4495-b2b1-dacb1a297b79.png)
2. View the [check result](https://github.com/woocommerce/woocommerce-google-analytics-integration/actions/runs/2629017053) of a caller repo after adding the input. There is no warning of `Unexpected input(s) 'php-version'`.
   ![image](https://user-images.githubusercontent.com/17420811/177760536-b3e82592-3bfc-41f8-ba0a-21bee7de87bb.png)
   ![image](https://user-images.githubusercontent.com/17420811/177760575-7a120a60-5209-4150-a63a-79eba92b7e53.png)
   - The three errors are testing the phpcs-diff for this PR - https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/218
