### PR TITLE
Add a new generator for setting up PHPCS with WordPress coding standards

### DIFF
--- a/packages/js/generator-grow/README.md
+++ b/packages/js/generator-grow/README.md
@@ -20,6 +20,7 @@ To generate everything, you can run `yo grow` and follow the prompts.
 Or call task separately:
 - `yo grow:github` GitHub Issue templates & co.
 - `yo grow:dotfiles`
+- `yo grow:phpcs` PHPCS with WordPress coding standards.
 
 <p align="center">
 	<br/><br/>

--- a/packages/js/generator-grow/generators/phpcs/USAGE
+++ b/packages/js/generator-grow/generators/phpcs/USAGE
@@ -10,8 +10,8 @@ Description:
 
   - PHPCS config file
 
-    Create a phpcs.xml.dist or phpcs.xml file for configuring PHPCS.
-    It will also ask about the text domain and exclusion patterns.
+    Create a phpcs.xml.dist file for configuring PHPCS. It will also ask about
+    the text domain and exclusion patterns.
 
   - Local scripts
 

--- a/packages/js/generator-grow/generators/phpcs/USAGE
+++ b/packages/js/generator-grow/generators/phpcs/USAGE
@@ -1,0 +1,7 @@
+Description:
+  Set up PHPCS with WordPress coding standards to run the PHPCS check in the
+  local environment and GitHub Actions.
+
+  If it's introducing PHPCS into a legacy repository for the first time,
+  choosing to perform the check on the changed lines of code would be helpful
+  to fix the existing codebase gradually.

--- a/packages/js/generator-grow/generators/phpcs/USAGE
+++ b/packages/js/generator-grow/generators/phpcs/USAGE
@@ -1,7 +1,34 @@
 Description:
-  Set up PHPCS with WordPress coding standards to run the PHPCS check in the
-  local environment and GitHub Actions.
+  - Check on the changed lines of code only - Diff mode
 
-  If it's introducing PHPCS into a legacy repository for the first time,
-  choosing to perform the check on the changed lines of code would be helpful
-  to fix the existing codebase gradually.
+    Set up PHPCS with WordPress coding standards to run the PHPCS check in the
+    local environment and GitHub Actions.
+
+    If it's introducing PHPCS into a legacy repository for the first time,
+    choosing to perform the check on the changed lines of code would be helpful
+    to fix the existing codebase gradually.
+
+  - PHPCS config file
+
+    Create a phpcs.xml.dist or phpcs.xml file for configuring PHPCS.
+    It will also ask about the text domain and exclusion patterns.
+
+  - Local scripts
+
+    Add `lint:php` script into package.json.
+
+    With diff mode, it will also add `lint:php:diff` script into package.json and
+    create a bash script under ./bin to run the check locally.
+
+  - Github Actions check
+
+    Set up a workflow file under .github/workflows to check PHPCS in Github Actions.
+    It will also ask preferred PHP version of the check job in Github Actions.
+
+    With non-diff mode, the branches are used to specify the triggering branches of
+    a push event in GitHub Actions.
+
+  - Required composer packages
+
+    Running PHPCS locally requires some composer packages. Please select packages
+    that are not yet installed or need to be updated.

--- a/packages/js/generator-grow/generators/phpcs/index.js
+++ b/packages/js/generator-grow/generators/phpcs/index.js
@@ -39,15 +39,6 @@ export default class PhpcsGenerator extends Generator {
 
 		// PHPCS configuration
 		if ( this.answers.installConfig ) {
-			const filenameAnswer = await this.prompt( {
-				type: 'list',
-				name: 'configFilename',
-				message: 'Which PHPCS config file name is preferred?',
-				...this._prepareConfigFileOptions(),
-			} );
-
-			Object.assign( this.answers, filenameAnswer );
-
 			furtherQuestions.push(
 				{
 					type: 'input',
@@ -132,9 +123,10 @@ export default class PhpcsGenerator extends Generator {
 
 		// PHPCS configuration
 		if ( answers.installConfig ) {
+			const filename = 'phpcs.xml.dist';
 			this.fs.copyTpl(
-				this.templatePath( 'phpcs.xml.dist' ),
-				this.destinationPath( answers.configFilename ),
+				this.templatePath( filename ),
+				this.destinationPath( filename ),
 				answers
 			);
 		}
@@ -179,15 +171,6 @@ export default class PhpcsGenerator extends Generator {
 		}
 	}
 
-	_prepareConfigFileOptions() {
-		const choices = [ 'phpcs.xml.dist', 'phpcs.xml' ];
-		const defaultVal =
-			choices.find( ( filename ) =>
-				this.existsDestination( filename )
-			) || choices[ 0 ];
-		return { choices, default: defaultVal };
-	}
-
 	_findTextDomain() {
 		// Ref: https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains
 		const mainFile = `${ path.basename( this.contextRoot ) }.php`;
@@ -203,10 +186,13 @@ export default class PhpcsGenerator extends Generator {
 	}
 
 	_findExclusionPatterns() {
-		const { configFilename } = this.answers;
 		const patterns = [];
+		const configFilename = [
+			'phpcs.xml.dist',
+			'phpcs.xml',
+		].find( ( filename ) => this.existsDestination( filename ) );
 
-		if ( this.existsDestination( configFilename ) ) {
+		if ( configFilename ) {
 			const content = this.readDestination( configFilename );
 			const regex = /<exclude-pattern>([^<]+)<\/exclude-pattern>/g;
 			content.replace( regex, ( _, pattern ) => {

--- a/packages/js/generator-grow/generators/phpcs/index.js
+++ b/packages/js/generator-grow/generators/phpcs/index.js
@@ -1,0 +1,247 @@
+/**
+ * External dependencies
+ */
+import path from 'path';
+import Generator from 'yeoman-generator';
+
+export default class PhpcsGenerator extends Generator {
+	async prompting() {
+		this.answers = await this.prompt( [
+			{
+				type: 'confirm',
+				name: 'isDiffOnly',
+				message:
+					'Would you like to perform the PHPCS check on the changed lines of code only?',
+				default: false,
+			},
+			{
+				type: 'confirm',
+				name: 'installConfig',
+				message: 'Whether to create the PHPCS config file?',
+				default: true,
+			},
+			{
+				type: 'confirm',
+				name: 'installLocalScripts',
+				message:
+					'Whether to set up npm scripts for running the check locally?',
+				default: true,
+			},
+			{
+				type: 'confirm',
+				name: 'installGithubAction',
+				message: 'Whether to run the check in GitHub Actions?',
+				default: false,
+			},
+		] );
+
+		const furtherQuestions = [];
+
+		// PHPCS configuration
+		if ( this.answers.installConfig ) {
+			const filenameAnswer = await this.prompt( {
+				type: 'list',
+				name: 'configFilename',
+				message: 'Which PHPCS config file name is preferred?',
+				...this._prepareConfigFileOptions(),
+			} );
+
+			Object.assign( this.answers, filenameAnswer );
+
+			furtherQuestions.push(
+				{
+					type: 'input',
+					name: 'textDomain',
+					message:
+						'What is the text domain for the i18n strings of this plugin?',
+					default: this._findTextDomain(),
+				},
+				{
+					type: 'editor',
+					name: 'excludePatterns',
+					message:
+						'What are the exclusion patterns of PHPCS config to be set?',
+					default: this._findExclusionPatterns().join( '\n' ),
+					filter( input ) {
+						return input
+							.split( '\n' )
+							.map( ( el ) => el.trim() )
+							.filter( Boolean );
+					},
+				}
+			);
+		}
+
+		// GitHub action
+		if ( this.answers.installGithubAction ) {
+			furtherQuestions.push( {
+				type: 'list',
+				name: 'phpVersion',
+				message: 'What PHP version to use in GitHub Actions?',
+				choices: [ '8.1', '8.0', '7.4', '7.3', '7.2' ],
+				default: '7.4',
+			} );
+
+			if ( ! this.answers.isDiffOnly ) {
+				// Only php-coding-standards.yml will be triggered by push events.
+				furtherQuestions.push( {
+					type: 'input',
+					name: 'branches',
+					message:
+						'What branches of push events should trigger this check in GitHub Actions? (separate branches by commas)',
+					default: this._findPersistentBranches().join( ', ' ),
+					filter( input ) {
+						return input.split( /\s*,\s*/ ).filter( Boolean );
+					},
+				} );
+			}
+		}
+
+		// Required composer packages
+		const depsQuestion = {
+			type: 'checkbox',
+			name: 'installDeps',
+			message:
+				'If you would like to install the required composer packages together, please select the wanted packages.',
+			choices: [
+				'dealerdirect/phpcodesniffer-composer-installer:^v0.7',
+				'wp-coding-standards/wpcs:^2.3',
+			],
+			default: [],
+		};
+
+		if ( this.answers.isDiffOnly ) {
+			depsQuestion.choices.push( 'exussum12/coverage-checker:^1.0' );
+		}
+
+		furtherQuestions.push( depsQuestion );
+		const furtherAnswers = await this.prompt( furtherQuestions );
+		Object.assign( this.answers, furtherAnswers );
+	}
+
+	install() {
+		const { installDeps } = this.answers;
+		if ( installDeps.length ) {
+			const opts = [ 'require', '--dev', ...installDeps ];
+			this.spawnCommand( 'composer', opts );
+		}
+	}
+
+	writing() {
+		const { answers } = this;
+
+		// PHPCS configuration
+		if ( answers.installConfig ) {
+			this.fs.copyTpl(
+				this.templatePath( 'phpcs.xml.dist' ),
+				this.destinationPath( answers.configFilename ),
+				answers
+			);
+		}
+
+		// GitHub action
+		if ( answers.installGithubAction ) {
+			const filename = answers.isDiffOnly
+				? 'php-coding-standards-diff.yml'
+				: 'php-coding-standards.yml';
+
+			this.fs.copyTpl(
+				this.templatePath( filename ),
+				this.destinationPath( `.github/workflows/${ filename }` ),
+				answers
+			);
+		}
+
+		// Add mpm scripts to package.json and bash file for phpcs-diff
+		if ( answers.installLocalScripts ) {
+			const scripts = { 'lint:php': 'vendor/bin/phpcs' };
+
+			if ( answers.isDiffOnly ) {
+				const filename = 'phpcs-diff.sh';
+				const destPath = `./bin/${ filename }`;
+				this.fs.copyTpl(
+					this.templatePath( filename ),
+					this.destinationPath( destPath )
+				);
+
+				scripts[ 'lint:php:diff' ] = destPath;
+			}
+
+			this.fs.extendJSON(
+				this.destinationPath( 'package.json' ),
+				{ scripts },
+				null,
+				this._getPackageJsonIndent()
+			);
+
+			// Skip `npm install` because it only changes the "scripts" config.
+			this.env.options.skipInstall = true;
+		}
+	}
+
+	_prepareConfigFileOptions() {
+		const choices = [ 'phpcs.xml.dist', 'phpcs.xml' ];
+		const defaultVal =
+			choices.find( ( filename ) =>
+				this.existsDestination( filename )
+			) || choices[ 0 ];
+		return { choices, default: defaultVal };
+	}
+
+	_findTextDomain() {
+		// Ref: https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains
+		const mainFile = `${ path.basename( this.contextRoot ) }.php`;
+
+		if ( this.existsDestination( mainFile ) ) {
+			const content = this.readDestination( mainFile );
+			const matched = content.match( /^\s*\* Text Domain: (.+)/im );
+			if ( matched ) {
+				return matched[ 1 ];
+			}
+		}
+		return '';
+	}
+
+	_findExclusionPatterns() {
+		const { configFilename } = this.answers;
+		const patterns = [];
+
+		if ( this.existsDestination( configFilename ) ) {
+			const content = this.readDestination( configFilename );
+			const regex = /<exclude-pattern>([^<]+)<\/exclude-pattern>/g;
+			content.replace( regex, ( _, pattern ) => {
+				patterns.push( pattern );
+			} );
+		} else {
+			patterns.push( '*/node_modules/*', '*/vendor/*', './assets/*' );
+		}
+		return patterns;
+	}
+
+	_findPersistentBranches() {
+		const possibleBranches = [ 'main', 'trunk', 'develop', 'dev' ];
+		let branches = [];
+
+		try {
+			const { stdout } = this.spawnCommandSync(
+				'git',
+				[ 'branch', '-r' ],
+				{ stdio: [ process.stdout ] }
+			);
+			branches = stdout
+				.split( '\n' )
+				.map( ( el ) => el.replace( /^\s*[^\/]+\//, '' ) )
+				.filter( ( el ) => possibleBranches.includes( el ) );
+		} catch ( e ) {
+			// Do nothing.
+		}
+
+		return branches;
+	}
+
+	_getPackageJsonIndent() {
+		const content = this.readDestination( 'package.json' );
+		const match = content.match( /^[ \t]+/m ) || [ '  ' ];
+		return match[ 0 ];
+	}
+}

--- a/packages/js/generator-grow/generators/phpcs/templates/php-coding-standards-diff.yml
+++ b/packages/js/generator-grow/generators/phpcs/templates/php-coding-standards-diff.yml
@@ -1,0 +1,21 @@
+name: PHP Coding Standards - Diff
+
+on:
+  pull_request:
+    paths:
+      - "**.php"
+      - .github/workflows/php-coding-standards-diff.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  CodingStandardsDiff:
+    name: PHP coding standards - diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run PHPCS to changed lines of code
+        uses: woocommerce/grow/phpcs-diff@actions-v1
+        with:
+          php-version: <%= phpVersion %>

--- a/packages/js/generator-grow/generators/phpcs/templates/php-coding-standards.yml
+++ b/packages/js/generator-grow/generators/phpcs/templates/php-coding-standards.yml
@@ -1,0 +1,39 @@
+name: PHP Coding Standards
+
+on:
+  push:
+    branches:
+<% branches.forEach((branch) => { -%>
+      - "<%- branch %>"
+<% }); -%>
+    paths:
+      - "**.php"
+      - .github/workflows/php-coding-standards.yml
+  pull_request:
+    paths:
+      - "**.php"
+      - .github/workflows/php-coding-standards.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpcs:
+    name: PHP coding standards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@actions-v1
+        with:
+          php-version: <%= phpVersion %>
+          tools: cs2pr
+
+      - name: Log PHPCS information
+        run: vendor/bin/phpcs -i
+
+      - name: Run PHPCS on all files
+        run: vendor/bin/phpcs ./* -q --report=checkstyle | cs2pr

--- a/packages/js/generator-grow/generators/phpcs/templates/phpcs-diff.sh
+++ b/packages/js/generator-grow/generators/phpcs/templates/phpcs-diff.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+GIT_LOG=$(git log -100 --graph --pretty=format:'%H %D')
+
+# Find the nearest commit which may be the parent of HEAD.
+# 1. Branch off from the default or another branch without any new commit.
+# 2. Branch off from the default or another branch and has new commits.
+LINE=1
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMITS=$(echo "$GIT_LOG" | grep -E '^\* (  \w{40}|\w{40} .+, )')
+if echo "$COMMITS" | grep -q "origin/${CURRENT_BRANCH}"; then
+	LINE=2
+fi
+COMMIT=$(echo "$COMMITS" | sed -n "${LINE}p")
+SHA=$(echo "$COMMIT" | awk '{print $2}')
+
+echo "$COMMIT" | sed 's/* */Diff target: /'
+vendor/bin/diffFilter --phpcsStrict <(git diff $SHA) <(vendor/bin/phpcs ./* -q --report=json) 0

--- a/packages/js/generator-grow/generators/phpcs/templates/phpcs.xml.dist
+++ b/packages/js/generator-grow/generators/phpcs/templates/phpcs.xml.dist
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Plugins">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
+
+	<!-- Set the minimum WP version -->
+	<config name="minimum_supported_wp_version" value="5.8"/>
+
+	<rule ref="WordPress">
+		<!-- We don't require conforming to WP file naming -->
+		<exclude name="WordPress.Files.FileName"/>
+
+		<!-- These comments are unnecessary -->
+		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
+		<exclude name="Squiz.Commenting.FileComment"/>
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+		<exclude name="Squiz.Commenting.LongConditionClosingComment"/>
+
+		<!-- No thanks -->
+		<exclude name="WordPress.PHP.DisallowShortTernary"/>
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+
+		<!-- These overrides are useful for code hinting -->
+		<exclude name="Generic.CodeAnalysis.UselessOverridingMethod.Found"/>
+
+		<!-- We like short array syntax -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+
+		<!-- Multiple throws tags are fine -->
+		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
+	</rule>
+
+	<!-- Disallow Yoda conditions. -->
+	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
+
+	<!-- Include some other sniffs we want to enforce. -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+	<rule ref="Generic.VersionControl.GitMergeConflict"/>
+	<rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter"/>
+	<rule ref="PSR12.Classes.AnonClassDeclaration"/>
+	<rule ref="PSR12.Classes.ClassInstantiation"/>
+	<rule ref="PSR12.Files.ImportStatement"/>
+	<rule ref="PSR12.Functions.NullableTypeDeclaration"/>
+	<rule ref="PSR12.Functions.ReturnTypeDeclaration"/>
+	<rule ref="PSR12.Properties.ConstantVisibility"/>
+	<rule ref="PSR12.Traits.UseDeclaration"/>
+	<rule ref="Squiz.Classes">
+		<exclude name="Squiz.Classes.ClassDeclaration.OpenBraceNewLine"/>
+		<exclude name="Squiz.Classes.ClassDeclaration.CloseBraceSameLine"/>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
+
+	<!-- Set the appropriate text domain. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="<%= textDomain %>"/>
+		</properties>
+	</rule>
+
+	<!-- This rule flags space indents in HTML tags, which are generally OK. -->
+	<rule ref="WordPress.WhiteSpace.PrecisionAlignment">
+		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found"/>
+	</rule>
+
+	<!-- We allow the use of / in hooks -->
+	<rule ref="WordPress.NamingConventions.ValidHookName">
+		<properties>
+			<property name="additionalWordDelimiters" value="/"/>
+		</properties>
+	</rule>
+
+	<!-- We don't use these functions for purposes of obfuscation -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<properties>
+			<property name="exclude" type="array">
+				<element value="obfuscation"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- We'd rather use native functions -->
+	<rule ref="WordPress.WP.AlternativeFunctions">
+		<properties>
+			<property name="exclude" type="array">
+				<element value="json_encode"/>
+				<element value="rand"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Check PHP files -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
+
+	<!-- Exclusion patterns -->
+<% excludePatterns.forEach((pattern) => { -%>
+	<exclude-pattern><%- pattern %></exclude-pattern>
+<% }); -%>
+</ruleset>

--- a/packages/js/generator-grow/generators/phpcs/templates/phpcs.xml.dist
+++ b/packages/js/generator-grow/generators/phpcs/templates/phpcs.xml.dist
@@ -31,9 +31,6 @@
 		<exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
 	</rule>
 
-	<!-- Disallow Yoda conditions. -->
-	<rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
-
 	<!-- Include some other sniffs we want to enforce. -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 	<rule ref="Generic.VersionControl.GitMergeConflict"/>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a new generator for setting up PHPCS with WordPress coding standards. It helps run PHPCS in the local development and GitHub Actions, and It has two modes:

1. Runs check for all PHP files.
2. Runs check for the changed lines of code only.

### Screenshots:

The changes of this PR https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/218 were generated by this generator.

![2022-07-07 17 54 21](https://user-images.githubusercontent.com/17420811/177762008-45bbd0df-c199-4f33-bf1b-1ed39898e42a.png)

### Detailed test instructions:

1. Git checkout the `add/generator-phpcs` branch of the grow repo.
2. Follow the [prerequisites](https://github.com/woocommerce/grow/tree/f27d216adf0712928923c0a1bf6d5019f3b5b3aa/packages/js/generator-grow#prerequisites) to set up yeoman.
3. Git checkout the `trunk` branch of [this repo](https://github.com/woocommerce/woocommerce-google-analytics-integration).
4. `cd` to the `woocommerce-google-analytics-integration` directory.
5. `yo grow:phpcs` and test different combinations of the prompts to see if the generator runs correctly.
6. Follow the test instructions in https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/218 to see if the generated PHPCS setup can run locally.