### PR TITLE
Fix the JSON syntax error of running `phpcd-diff` action when no changes are made

### DIFF
--- a/packages/js/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/js/github-actions/actions/phpcs-diff/action.yml
@@ -28,6 +28,8 @@ runs:
         JSON_REPORT="/tmp/phpcs-diff.json"
         vendor/bin/diffFilter --phpcsStrict <(git diff HEAD^...HEAD) <(vendor/bin/phpcs ./* -q --report=json) --report=phpcs 0 > "$JSON_REPORT"
 
+        # It's a workaround that prevents the empty result from being passed as a JSON file to annotate-phpcs-report.js
+        # Related issue: https://github.com/exussum12/coverageChecker/issues/72
         if [ ! -s "$JSON_REPORT" ]; then
           echo "No changes."
           exit 0

--- a/packages/js/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/js/github-actions/actions/phpcs-diff/action.yml
@@ -25,12 +25,19 @@ runs:
       # a workflow to a pull request, it uses the revision of a merge commit to run the workflow
       # as well. Therefore, `git diff HEAD^...HEAD` includes all diffs of a PR.
       run: |
-        vendor/bin/diffFilter --phpcsStrict <(git diff HEAD^...HEAD) <(vendor/bin/phpcs ./* -q --report=json) --report=phpcs 0 > /tmp/phpcs-diff.json
+        JSON_REPORT="/tmp/phpcs-diff.json"
+        vendor/bin/diffFilter --phpcsStrict <(git diff HEAD^...HEAD) <(vendor/bin/phpcs ./* -q --report=json) --report=phpcs 0 > "$JSON_REPORT"
+
+        if [ ! -s "$JSON_REPORT" ]; then
+          echo "No changes."
+          exit 0
+        fi
+
         cd "${{ github.action_path }}"
-        node annotate-phpcs-report.js /tmp/phpcs-diff.json
+        node annotate-phpcs-report.js "$JSON_REPORT"
         cd -
 
-        TOTAL_ERRORS=$(jq ".totals.errors" /tmp/phpcs-diff.json)
+        TOTAL_ERRORS=$(jq ".totals.errors" "$JSON_REPORT"
         if [ "$TOTAL_ERRORS" != "0" ]; then
           exit 1
         fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix the JSON syntax error of running `phpcd-diff` action when no changes are made. 

For some reason, if runs `phpcs-diff` action without any file changes, it will get a JSON syntax error because the `vendor/bin/diffFilter` outputs an empty result.

![image](https://user-images.githubusercontent.com/17420811/177947056-25bc71b2-107b-49c1-9ba4-948ad813c656.png)

### Detailed test instructions:

1. Create a local bash file at the repo's root directory temporality to verify the changes of this PR.
   ```bash
   #!/usr/bin/env bash
   JSON_REPORT="/tmp/phpcs-diff.json"

   # The original command
   # vendor/bin/diffFilter --phpcsStrict <(git diff HEAD^...HEAD) <(vendor/bin/phpcs ./* -q --report=json) --report=phpcs 0 > "$JSON_REPORT"

   # Simulate the result of no changes - an empty file.
   printf '' > "$JSON_REPORT"

   # Simulate the result of no PHPCS errors.
   # printf '{"files":[],"totals":{"errors":0,"fixable":0,"warnings":0}}' > "$JSON_REPORT"

   # Simulate the result of a PHPCS error.
   # printf '{"files":{"woocommerce-google-analytics-integration.php":{"messages":[{"message":"Expected 1 spaces before closing parenthesis; 0 found","source":"diffFilter","severity":1,"type":"ERROR","line":23,"column":1,"fixable":"false"}],"errors":1,"warnings":0}},"totals":{"errors":1,"fixable":0,"warnings":0}}' > "$JSON_REPORT"

   if [ ! -s "$JSON_REPORT" ]; then
     echo "No changes."
     exit 0
   fi

   node packages/js/github-actions/actions/phpcs-diff/src/annotate-phpcs-report.js "$JSON_REPORT"
   ```
2. Run the verification bash file with different diff results to see if the fix works well.
