### PR TITLE
Add "dev" change type to `branch-label` GHA,

### DIFF
--- a/packages/js/github-actions/actions/branch-label/action.yml
+++ b/packages/js/github-actions/actions/branch-label/action.yml
@@ -32,6 +32,11 @@ runs:
         labels: |
           changelog: tweak
     - uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.head_ref, 'dev/') }}
+      with:
+        labels: |
+          changelog: dev
+    - uses: actions-ecosystem/action-add-labels@v1
       if: ${{ startsWith(github.head_ref, 'doc/') }}
       with:
         labels: |


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Add "dev" change type to `branch-label` GHA,
to match the convention from https://github.com/woocommerce/google-listings-and-ads/pull/1565#issuecomment-1163223328


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
See https://github.com/tomalec/gla-gh-notes/pull/13 for an example.

1. Add a workflow to a test repo
```yaml
name: Set PR Labels

on:
  pull_request:
    types: opened
jobs:
  SetLabels:
    runs-on: ubuntu-latest
    steps:
      - name: Set Labels
        uses: woocommerce/grow/packages/js/github-actions/actions/branch-label@add/dev-label
```
3. Create a PR for a `dev/something` branch


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - `dev` type to branch-label GHA
