### PR TITLE
Fix a bash script syntax error in the `phpcs-diff` action

### DIFF
--- a/packages/js/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/js/github-actions/actions/phpcs-diff/action.yml
@@ -47,7 +47,7 @@ runs:
         node annotate-phpcs-report.js "$JSON_REPORT"
         cd -
 
-        TOTAL_ERRORS=$(jq ".totals.errors" "$JSON_REPORT"
+        TOTAL_ERRORS=$(jq ".totals.errors" "$JSON_REPORT")
         if [ "$TOTAL_ERRORS" != "0" ]; then
           exit 1
         fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix the missing `)` in the action.yml of `phpcs-diff` action.

### Detailed test instructions:

Check if the syntax of packages/js/github-actions/actions/phpcs-diff/action.yml is correct.
