### PR TITLE
Add annotation actions of `eslint` and `stylelint` for annotating the linting results via their formatter

### DIFF
--- a/packages/js/github-actions/README.md
+++ b/packages/js/github-actions/README.md
@@ -7,11 +7,13 @@ Custom GitHub actions that help to composite GitHub workflows across the repos m
 ## Actions list
 
 - [`branch-label`](actions/branch-label) - Set PR labels according to the branch name
+- [`eslint-annotation`](actions/eslint-annotation) - Annotate eslint results via eslint formatter
 - [`get-release-notes`](actions/get-release-notes) - Get release notes via GitHub, infer the next version and tag
 - [`phpcs-diff`](actions/phpcs-diff) - Run PHPCS to the changed lines of code, set error annotations to a pull request
 - [`prepare-mysql`](actions/prepare-mysql) - Enable MySQL, handle authentication compatibility
 - [`prepare-node`](actions/prepare-node) - Set up Node.js with a specific version, load npm cache, install Node dependencies
 - [`prepare-php`](actions/prepare-php) - Set up PHP with a specific version and tools, load Composer cache, install Composer dependencies
+- [`stylelint-annotation`](actions/stylelint-annotation) - Annotate stylelint results via stylelint formatter
 - [`update-version-tags`](actions/update-version-tags) - Update version tags
 
 ## Prerequisites

--- a/packages/js/github-actions/actions/eslint-annotation/README.md
+++ b/packages/js/github-actions/actions/eslint-annotation/README.md
@@ -1,0 +1,38 @@
+# ESLint formatter to annotate the linting results in GitHub Actions
+
+This action provides the following functionality for GitHub Actions users:
+
+- Annotate the errors and warnings of eslint results in GitHub Actions.
+
+## Usage
+
+See [action.yml](action.yml)
+
+## Compatibility
+
+- `eslint` >= 7
+
+#### Basic:
+
+```yaml
+name: ESLint
+
+on:
+  pull_request:
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - uses: woocommerce/grow/eslint-annotation@actions-v1
+        with:
+          formatter-dest: "./my-formatter.cjs"
+      - run: eslint --format ./my-formatter.cjs src
+```
+
+Uses .cjs to ensure the formatter script will be imported as a CommonJS module.

--- a/packages/js/github-actions/actions/eslint-annotation/action.yml
+++ b/packages/js/github-actions/actions/eslint-annotation/action.yml
@@ -1,0 +1,18 @@
+name: ESlint annotattion formatter
+description: Annotate eslint results via eslint formatter.
+
+inputs:
+  formatter-dest:
+    description: The relative path to place the eslint formatter script. Please use a destination file path within the caller repository since the script will depends on the eslint package installed in it.
+    default: "./eslintFormatter.cjs"
+
+runs:
+  using: composite
+  steps:
+    # Copy formatter script to the destination file path.
+    - shell: bash
+      run: |
+        SCRIPT_DEST="${{ inputs.formatter-dest }}"
+        mkdir -p $(dirname "$SCRIPT_DEST")
+        echo '/* eslint-disable */' > "$SCRIPT_DEST"
+        cat "${{ github.action_path }}/eslintFormatter.cjs" >> "$SCRIPT_DEST"

--- a/packages/js/github-actions/actions/eslint-annotation/src/eslintFormatter.js
+++ b/packages/js/github-actions/actions/eslint-annotation/src/eslintFormatter.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { ESLint } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import annotateByWorkflowCommand from '../../../utils/annotate-by-workflow-command.js';
+
+function toAnnotations( failedFiles ) {
+	const truncationPath = process.cwd();
+	const annotations = [];
+
+	failedFiles.forEach( ( file ) => {
+		const filePath = file.filePath.replace( truncationPath, '.' );
+
+		file.messages.forEach( ( lintError ) => {
+			const { severity, ruleId, message } = lintError;
+
+			// About the `severity` value: https://eslint.org/docs/user-guide/formatters/#json
+			annotations.push( {
+				...lintError,
+				command: severity === 2 ? 'error' : 'warning',
+				filePath,
+				message: `[${ ruleId }] ${ message }`,
+			} );
+		} );
+	} );
+
+	return annotations;
+}
+
+// Ref: https://eslint.org/docs/developer-guide/working-with-custom-formatters
+export default function ( results, context ) {
+	const failedFiles = results.filter(
+		( { errorCount, warningCount } ) => errorCount || warningCount
+	);
+	const annotations = toAnnotations( failedFiles );
+	annotateByWorkflowCommand( annotations );
+
+	// Try to still output the original CLI logs by default format.
+	try {
+		const major = Number( ESLint.version.split( '.', 1 ).pop() );
+		const promise = new ESLint().loadFormatter().then( ( formatter ) => {
+			return formatter.format( results, context );
+		} );
+
+		// The eslint version less than 8 doesn't support running formatter in async.
+		if ( major < 8 ) {
+			promise.then( ( report ) => console.log( report ) ); // eslint-disable-line no-console
+			return '';
+		}
+		return promise;
+	} catch ( e ) {
+		// No-op.
+	}
+}

--- a/packages/js/github-actions/actions/stylelint-annotation/README.md
+++ b/packages/js/github-actions/actions/stylelint-annotation/README.md
@@ -1,0 +1,38 @@
+# Stylelint formatter to annotate the linting results in GitHub Actions
+
+This action provides the following functionality for GitHub Actions users:
+
+- Annotate the errors and warnings of stylelint results in GitHub Actions.
+
+## Usage
+
+See [action.yml](action.yml)
+
+## Compatibility
+
+- `stylelint` >= 13
+
+#### Basic:
+
+```yaml
+name: Stylelint
+
+on:
+  pull_request:
+
+jobs:
+  stylelint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - uses: woocommerce/grow/stylelint-annotation@actions-v1
+        with:
+          formatter-dest: "./my-formatter.cjs"
+      - run: stylelint --custom-formatter ./my-formatter.cjs "**/*.css"
+```
+
+Uses .cjs to ensure the formatter script will be imported as a CommonJS module.

--- a/packages/js/github-actions/actions/stylelint-annotation/action.yml
+++ b/packages/js/github-actions/actions/stylelint-annotation/action.yml
@@ -1,0 +1,18 @@
+name: Stylelint annotattion formatter
+description: Annotate stylelint results via stylelint formatter.
+
+inputs:
+  formatter-dest:
+    description: The relative path to place the stylelint formatter script. Please use a destination file path within the caller repository since the script will depends on the stylelint package installed in it.
+    default: "./stylelintFormatter.cjs"
+
+runs:
+  using: composite
+  steps:
+    # Copy formatter script to the destination file path.
+    - shell: bash
+      run: |
+        SCRIPT_DEST="${{ inputs.formatter-dest }}"
+        mkdir -p $(dirname "$SCRIPT_DEST")
+        echo '/* eslint-disable */' > "$SCRIPT_DEST"
+        cat "${{ github.action_path }}/stylelintFormatter.cjs" >> "$SCRIPT_DEST"

--- a/packages/js/github-actions/actions/stylelint-annotation/src/stylelintFormatter.js
+++ b/packages/js/github-actions/actions/stylelint-annotation/src/stylelintFormatter.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import stylelint from 'stylelint';
+
+/**
+ * Internal dependencies
+ */
+import annotateByWorkflowCommand from '../../../utils/annotate-by-workflow-command.js';
+
+function toAnnotations( failedFiles ) {
+	const truncationPath = process.cwd();
+	const annotations = [];
+
+	failedFiles.forEach( ( file ) => {
+		const filePath = file.source.replace( truncationPath, '.' );
+
+		file.warnings.forEach( ( lintError ) => {
+			const { severity, line, column, text } = lintError;
+
+			annotations.push( {
+				command: severity,
+				filePath,
+				line,
+				column,
+				message: text,
+			} );
+		} );
+	} );
+
+	return annotations;
+}
+
+// Ref: https://stylelint.io/developer-guide/formatters/
+export default function ( results, returnValue ) {
+	const failedFiles = results.filter( ( { warnings } ) => warnings.length );
+	const annotations = toAnnotations( failedFiles );
+	annotateByWorkflowCommand( annotations );
+
+	// Try to still output the original CLI logs by default format.
+	try {
+		return stylelint.formatters.string( results, returnValue );
+	} catch ( e ) {
+		// No-op.
+	}
+}

--- a/packages/js/github-actions/rollup.config.js
+++ b/packages/js/github-actions/rollup.config.js
@@ -7,6 +7,16 @@ import json from '@rollup/plugin-json';
 
 export default [
 	{
+		input: './actions/eslint-annotation/src/eslintFormatter.js',
+		output: {
+			file: './actions/eslint-annotation/eslintFormatter.cjs',
+			format: 'cjs',
+			exports: 'auto',
+		},
+		// This action imports 'eslint' from the caller repo.
+		external: [ 'eslint' ],
+	},
+	{
 		input: './actions/get-release-notes/src/get-release-notes.js',
 		output: {
 			file: './actions/get-release-notes/get-release-notes.mjs',

--- a/packages/js/github-actions/rollup.config.js
+++ b/packages/js/github-actions/rollup.config.js
@@ -37,6 +37,16 @@ export default [
 		plugins: [ nodeResolve( { preferBuiltins: true } ), commonjs() ],
 	},
 	{
+		input: './actions/stylelint-annotation/src/stylelintFormatter.js',
+		output: {
+			file: './actions/stylelint-annotation/stylelintFormatter.cjs',
+			format: 'cjs',
+			exports: 'auto',
+		},
+		// This action imports 'stylelint' from the caller repo.
+		external: [ 'stylelint' ],
+	},
+	{
 		input: './actions/update-version-tags/src/update-version-tags.js',
 		output: {
 			file: './actions/update-version-tags/update-version-tags.mjs',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add annotation actions of `eslint` and `stylelint` for annotating the linting results via their formatters.

### Detailed test instructions:

1. View the draft PR #36 its Check tab for `eslint-annotation` action with eslint v8.x.
2. View the draft PR https://github.com/woocommerce/google-listings-and-ads/pull/1594 and its Check tab for `eslint-annotation` and `stylelint-annotation` actions with `eslint` v7.x.
   - [JavaScript linting](https://github.com/woocommerce/google-listings-and-ads/runs/7320548566?check_suite_focus=true)
   - [SCSS linting](https://github.com/woocommerce/google-listings-and-ads/runs/7320548227?check_suite_focus=true)
