### PR TITLE
Add monorepo release.yml to boilerplate generator

### DIFF
--- a/packages/js/generator-grow/generators/github/USAGE
+++ b/packages/js/generator-grow/generators/github/USAGE
@@ -1,3 +1,3 @@
 Description:
 	Creates a bunch of `.github/` files:
-	Issue & PR templates, CODE_OF_CONDUCT, CONTRIBUTING and SECURITY.md.
+	Issue & PR templates, release.yml, CODE_OF_CONDUCT, CONTRIBUTING and SECURITY.md.

--- a/packages/js/generator-grow/generators/github/templates/PULL_REQUEST_TEMPLATE.md
+++ b/packages/js/generator-grow/generators/github/templates/PULL_REQUEST_TEMPLATE.md
@@ -31,8 +31,9 @@ Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
 > Tweak - I made a small change.
 > Update - I made big changes to something that wasn't broken.
 
-Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
 If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
+
+Add the `changelog: none` label if no changelog entry is needed.
 -->
 ### Changelog entry
 

--- a/packages/js/generator-grow/generators/github/templates/PULL_REQUEST_TEMPLATE.md
+++ b/packages/js/generator-grow/generators/github/templates/PULL_REQUEST_TEMPLATE.md
@@ -25,11 +25,14 @@ _Replace this with a good description of your changes & reasoning._
 <!--
 Optional.
 Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
-Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
-> Fix - I took care of something that wasn't working.
-> Add - I added something new that's pretty cool.
-> Tweak - I made a small change.
-> Update - I made big changes to something that wasn't broken.
+Each line should start with change type prefix`(Fix|Add|…) - `, for example:
+> Break - A change breaking previous API or functionality.
+> Add - A new feature, function or functionality was added.
+> Update - Big changes to something that wasn't broken.
+> Fix - Took care of something that wasn't working.
+> Tweak - Small change, that isn't actually very important.
+> Dev - Developer-facing only change.
+> Doc - Updated customer or developer facing documentation
 
 If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
 

--- a/packages/js/generator-grow/generators/github/templates/release.yml
+++ b/packages/js/generator-grow/generators/github/templates/release.yml
@@ -1,0 +1,45 @@
+changelog:
+  exclude:
+    labels:
+      - "changelog: none"
+    authors:
+      - dependabot
+      - github-actions
+
+  categories:
+    # Major level
+    - title: "[Breaking] Breaking Changes 🚨"
+      labels:
+        - "changelog: breaking"
+
+    # Minor level
+    - title: "[Add] New Features 🎉"
+      labels:
+        - "changelog: add"
+        - "type: enhancement"
+
+    - title: "[Update] Updated ✨"
+      labels:
+        - "changelog: update"
+
+    # Patch level
+    - title: "[Fix] Fixes 🛠"
+      labels:
+        - "changelog: fix"
+        - "type: bug"
+
+    - title: "[Tweak] Tweaked 🔧"
+      labels:
+        - "changelog: tweak"
+
+    - title: "[Dev] Developer-facing changes 🧑‍💻"
+      labels:
+        - "changelog: dev"
+
+    - title: "[Doc] Documentation 📚"
+      labels:
+        - "changelog: docs"
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/packages/js/github-actions/release-notes-config.yml
+++ b/packages/js/github-actions/release-notes-config.yml
@@ -3,6 +3,8 @@ changelog:
     authors:
       - dependabot
       - github-actions
+    labels:
+      - "changelog: none"
 
   categories:
     # Major level


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Mostly, so we could ignore `woorelease` changelog entries with `changelog: none` label.

It also adds `chengelog: none` exclusion to GHA release config, so it would respect this label as well.

This PR may wait for the test ride of https://github.com/woocommerce/google-listings-and-ads/pull/1565 to finish.
I think the first release with the latest config and `woorelease@2.4.0` could give some input.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Git checkout the `add/release.yml` branch of the grow repo.
2. Follow the [prerequisites](https://github.com/woocommerce/grow/tree/f27d216adf0712928923c0a1bf6d5019f3b5b3aa/packages/js/generator-grow#prerequisites) to set up yeoman.
3. Git checkout the `develop` branch of [this repo](https://github.com/woocommerce/automatewoo).
4. `cd` to the `automatewoo` directory.
5. `yo grow:github` and test different combinations of the prompts to see if the generator runs correctly.
6. Check that `release.yml` is added correctly.



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Add - monorepo release.yml to boilerplate generator
