### PR TITLE
Update generator's and repo's PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,14 +25,18 @@ _Replace this with a good description of your changes & reasoning._
 <!--
 Optional.
 Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
-Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
-> Fix - I took care of something that wasn't working.
-> Add - I added something new that's pretty cool.
-> Tweak - I made a small change.
-> Update - I made big changes to something that wasn't broken.
+Each line should start with change type prefix`(Fix|Add|…) - `, for example:
+> Break - A change breaking previous API or functionality.
+> Add - A new feature, function or functionality was added.
+> Update - Big changes to something that wasn't broken.
+> Fix - Took care of something that wasn't working.
+> Tweak - Small change, that isn't actually very important.
+> Dev - Developer-facing only change.
+> Doc - Updated customer or developer facing documentation
 
-Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
-If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
+For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.
+
+Add the `changelog: none` label if no changelog entry is needed.
 -->
 ### Changelog entry
 

--- a/packages/js/generator-grow/generators/github/templates/PULL_REQUEST_TEMPLATE.md
+++ b/packages/js/generator-grow/generators/github/templates/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Each line should start with change type prefix`(Fix|Add|…) - `, for example:
 > Dev - Developer-facing only change.
 > Doc - Updated customer or developer facing documentation
 
-If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
+If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
 
 Add the `changelog: none` label if no changelog entry is needed.
 -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- [Fix grammar in the generator's PR template](https://github.com/woocommerce/grow/commit/597e16fd02e4507dce7108e3765109c6879647da) 
   Addresses https://github.com/woocommerce/google-listings-and-ads/pull/1613#pullrequestreview-1061441446
- [Update PR template](https://github.com/woocommerce/grow/commit/52116ff5d15e4b0e402c7be8330aebea829c5fdc) 
   Update types
   Mention the use of `changelog: none` exclusion.
   Remove `### Changelog entry` vs. PR title rule, as we do not use `woorelease` for this repo.
   Mention the use of `[actions] changelog: *` labels.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Review working in both templates.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Dev - Update generator's and repo's PR templates.
