### PR TITLE
Add branch-labels GH workflow to generator

### DIFF
--- a/packages/js/generator-grow/generators/github/github.test.js
+++ b/packages/js/generator-grow/generators/github/github.test.js
@@ -20,6 +20,11 @@ describe( ':github', function () {
 			assert.file( '.github/SECURITY.md' );
 		} );
 	} );
+	it( 'generate `.github/workflows/branch-labels.yml` file', async function () {
+		await helpers.run( githubPath ).then( function () {
+			assert.file( '.github/worflows/branch-labels.yml' );
+		} );
+	} );
 	it( 'Should use given project title in CONTRIBUTING.md', async function () {
 		await helpers
 			.run( githubPath )

--- a/packages/js/generator-grow/generators/github/templates/workflows/branch-labels.yml
+++ b/packages/js/generator-grow/generators/github/templates/workflows/branch-labels.yml
@@ -1,0 +1,11 @@
+name: Set PR Labels
+
+on:
+  pull_request:
+    types: opened
+jobs:
+  SetLabels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Labels
+        uses: woocommerce/grow/branch-label@actions-v1


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add branch-labels GH workflow,

to set changelog: * labels to PRs based on conventional branch names.

Workflow is copied from https://github.com/woocommerce/google-listings-and-ads/blob/develop/.github/workflows/branch-labels.yml


### Screenshots:
![image](https://user-images.githubusercontent.com/17435/184173329-e029af1a-646a-406f-819b-a6da8254191d.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. `cd packages/js/generator-grow/ && npm run test`
2. [Install/link the generator](https://github.com/woocommerce/grow/tree/trunk/packages/js/generator-grow#prerequisites)
3. Go to any repo/directory
4. run `yo grow:github`
5. Check the `.github/workflows/`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - branch-labels GH workflow to the generator
