### PR TITLE
Add coverage Report as PR comment

### DIFF
--- a/packages/js/github-actions/README.md
+++ b/packages/js/github-actions/README.md
@@ -7,6 +7,7 @@ Custom GitHub actions that help to composite GitHub workflows across the repos m
 ## Actions list
 
 - [`branch-label`](actions/branch-label) - Set PR labels according to the branch name
+- [`coverage-report`](actions/coverage-report) - Add a clover coverage report as a PR comment
 - [`eslint-annotation`](actions/eslint-annotation) - Annotate eslint results via eslint formatter
 - [`get-release-notes`](actions/get-release-notes) - Get release notes via GitHub, infer the next version and tag
 - [`phpcs-diff`](actions/phpcs-diff) - Run PHPCS to the changed lines of code, set error annotations to a pull request

--- a/packages/js/github-actions/actions/coverage-report/README.md
+++ b/packages/js/github-actions/actions/coverage-report/README.md
@@ -1,0 +1,39 @@
+# Prepare PHP in GitHub Actions
+
+This action adds a Unit test coverage report to the PR as a comment. The coverage report must be in the clover format.
+For main branches (trunk) the coverage report will be uploaded as a GitHub artifact. When the action is run as part of a PR the artifact from the main branch will be downloaded, and use as a comparison with the report in the current PR.
+This final report will be added to the PR as a comment.
+
+## Usage
+
+See [action.yml](action.yml)
+
+By default the artifact will be saved as `coverage-report` and the report will be found in the file `tests/coverage/report.xml`. The options `report-file`, `report-path` and `report-name` can be adjusted if we need to have multiple reports (one for JS unit tests and another for PHP unit tests).
+
+The parameter workflow must point to the current workflow file, which indicates where to save the downloaded artifact so it can be used in the comparison between branches.
+
+#### Basic:
+
+```yaml
+jobs:
+  UnitTests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@actions-v1
+
+      - name: Run unit tests (with coverage report)
+        run: phpdbg -qrr vendor/bin/phpunit --coverage-clover=tests/coverage/report.xml
+
+      - name: PHP unit coverage report
+        uses: woocommerce/grow/coverage-report@actions-v1
+        with:
+          base-branch: trunk
+          test-comment: "PHP unit test coverage"
+          workflow: .github/workflows/php-unit-tests.yml # Point to the current workflow
+```

--- a/packages/js/github-actions/actions/coverage-report/README.md
+++ b/packages/js/github-actions/actions/coverage-report/README.md
@@ -1,4 +1,4 @@
-# Prepare PHP in GitHub Actions
+# Unit Test Coverage Report in GitHub Actions
 
 This action adds a Unit test coverage report to the PR as a comment. The coverage report must be in the clover format.
 For main branches (trunk) the coverage report will be uploaded as a GitHub artifact. When the action is run as part of a PR the artifact from the main branch will be downloaded, and use as a comparison with the report in the current PR.

--- a/packages/js/github-actions/actions/coverage-report/action.yml
+++ b/packages/js/github-actions/actions/coverage-report/action.yml
@@ -27,6 +27,11 @@ inputs:
     required: false
     default: "Unit test coverage"
 
+  with-table:
+    description: Add a table with a list of files and its coverage
+    required: false
+    default: true
+
   workflow:
     description: Destination workflow where the downloaded artifact will be stored.
     required: true
@@ -59,5 +64,6 @@ runs:
         file: "${{ inputs.report-path }}/${{ inputs.report-file }}"
         base-file: "${{ inputs.report-path }}/${{ inputs.base-branch }}/${{ inputs.report-file }}"
         signature: ${{ inputs.test-comment }}
+        with-table: ${{ inputs.with-table }}
         table-above-coverage: 1
         table-below-coverage: 99

--- a/packages/js/github-actions/actions/coverage-report/action.yml
+++ b/packages/js/github-actions/actions/coverage-report/action.yml
@@ -1,0 +1,61 @@
+name: Coverage Report
+description: Parses a coverage report and adds it to the PR as a comment.
+
+inputs:
+  base-branch:
+    description: Base branch to compare coverage report with.
+    required: false
+    default: trunk
+
+  report-file:
+    description: Clover coverage report filename.
+    required: false
+    default: report.xml
+
+  report-path:
+    description: Path where reports are saved.
+    required: false
+    default: tests/coverage
+
+  report-name:
+    description: Artifact name of the saved report.
+    required: false
+    default: coverage-report
+
+  test-comment:
+    description: Test comment to describe type of test.
+    required: false
+    default: "Unit test coverage"
+
+  workflow:
+    description: Destination workflow where the downloaded artifact will be stored.
+    required: true
+
+runs:
+  using: composite
+  steps:
+
+    # Download coverage report artifact
+    - if: github.event_name == 'pull_request'
+      uses: dawidd6/action-download-artifact@v2.14.1
+      continue-on-error: true
+      with:
+        workflow: ${{ inputs.workflow }}
+        branch: ${{ inputs.base-branch }}
+        name: ${{ inputs.report-name }}
+        path: "${{ inputs.report-path }}/${{ inputs.base-branch }}"
+
+    # Save coverage report as an artifact
+    - if: github.event_name != 'pull_request'
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.report-name }}
+        path: "${{ inputs.report-path }}/${{ inputs.report-file }}"
+
+    # Coverage report as PR comment
+    - if: github.event_name == 'pull_request'
+      uses: lucassabreu/comment-coverage-clover@main
+      with:
+        file: "${{ inputs.report-path }}/${{ inputs.report-file }}"
+        base-file: "${{ inputs.report-path }}/${{ inputs.base-branch }}/${{ inputs.report-file }}"
+        signature: ${{ inputs.test-comment }}

--- a/packages/js/github-actions/actions/coverage-report/action.yml
+++ b/packages/js/github-actions/actions/coverage-report/action.yml
@@ -59,3 +59,5 @@ runs:
         file: "${{ inputs.report-path }}/${{ inputs.report-file }}"
         base-file: "${{ inputs.report-path }}/${{ inputs.base-branch }}/${{ inputs.report-file }}"
         signature: ${{ inputs.test-comment }}
+        table-above-coverage: 1
+        table-below-coverage: 99


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a workflow to upload a coverage report as a PR comment.

We can see it in action on this PR: https://github.com/woocommerce/automatewoo/pull/1356

Once approved this PR can be merged and released following the instructions here: https://github.com/woocommerce/grow/tree/trunk/packages/js/github-actions
When that's completed we can switch the action `uses` source within the AutomateWoo PR.

> **Note**
This action creates a PR comment for a coverage report regardless of the language of the unit tests. So it can be used for a PHP or JS unit test report, as long as the report is in the "clover" format.

### Detailed test instructions:
See test instuctions for PR https://github.com/woocommerce/automatewoo/pull/1356

### Changelog entry
* Dev - Add coverage report as PR comment