### PR TITLE
Replace the deprecated command `set-output` of GitHub Actions

### DIFF
--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -74,7 +74,7 @@ jobs:
           if [ "$TAG_NAME" = '' ]; then
             TAG_NAME="${{ fromJSON(needs.Setup.outputs.release || '{}').tag_name }}"
           fi
-          echo "::set-output name=tag_name::${TAG_NAME}"
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -126,7 +126,7 @@ jobs:
           git push -d origin tmp-gha-release-build
 
           git checkout HEAD^ -- ./packages/js/github-actions/actions
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Update version tags
         uses: ./update-version-tags

--- a/packages/js/github-actions/actions/prepare-php/action.yml
+++ b/packages/js/github-actions/actions/prepare-php/action.yml
@@ -47,7 +47,7 @@ runs:
     # Get Composer cache directory.
     - shell: bash
       id: composer-cache-config
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     # Set up Composer caching.
     - uses: actions/cache@v3


### PR DESCRIPTION
### Changes proposed in this Pull Request:

According to [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/):

> To avoid untrusted logged data to use save-stateand set-output workflow commands without the intention of the workflow author we have introduced a [new set of environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files) to manage state and output.

> We are monitoring telemetry for the usage of these commands and **plan to fully disable them on 31st May 2023**. Starting 1st June 2023 workflows using `save-state` or `set-output` commands via stdout will fail with an error.

This PR replaces the three uses of the stdout command `set-output` with the `GITHUB_OUTPUT` environment file.

1. https://github.com/woocommerce/grow/blob/dbf518e26d5a98dab65b1717542efbea527d441a/packages/js/github-actions/actions/prepare-php/action.yml#L50
2. https://github.com/woocommerce/grow/blob/dbf518e26d5a98dab65b1717542efbea527d441a/.github/workflows/github-actions-release.yml#L77
3. https://github.com/woocommerce/grow/blob/dbf518e26d5a98dab65b1717542efbea527d441a/.github/workflows/github-actions-release.yml#L129

### 📌 Checklist after merging this PR: (@eason9487)

- [x] Delete the testing release https://github.com/woocommerce/grow/releases/tag/actions-v1.4.1-pre
- [x] Delete the testing tags `actions-v1-pre`, `actions-v1.4-pre` and `actions-v1.4.1-pre`.

### Detailed test instructions:

#### .github/workflows/github-actions-release.yml

1. View the latest release job of version actions-v1.4.0: https://github.com/woocommerce/grow/actions/runs/4604724324
   - There are two warnings in the **Annotations** block.
   - The warnings come from these two positions: [#1](https://github.com/woocommerce/grow/actions/runs/4604724324/jobs/8135938801#step:2:9) and [#2](https://github.com/woocommerce/grow/actions/runs/4604724324/jobs/8135938801#step:5:186)
      ![image](https://user-images.githubusercontent.com/17420811/231724350-49ea2afa-4cff-42c1-8912-a1e129dd3c6c.png)
2. View the testing release job of this PR: https://github.com/woocommerce/grow/actions/runs/4687795132
   - There should be no longer warnings in the **Annotations** block.
   - Check if its release build 3bbb75a6d166d7d04df82397e0e334893e737d02 was created successfully.
   - Check if the [tag_name](https://github.com/woocommerce/grow/actions/runs/4687795132/jobs/8307531415#step:5:3) is passed with the right value.
      ![2023-04-13 18 21 12](https://user-images.githubusercontent.com/17420811/231731187-de66fdfd-41da-4bb0-a9b2-8c0e385f61c6.png)
   - Check if the [sha](https://github.com/woocommerce/grow/actions/runs/4687795132/jobs/8307531415#step:6:4) is passed with the right value.
      ![image](https://user-images.githubusercontent.com/17420811/231731352-d39dd1fc-d9e8-43e2-9e78-f97d37f23c15.png)

#### packages/js/github-actions/actions/prepare-php/action.yml

1. View a job that used the `prepare-php` action in GLA: https://github.com/woocommerce/google-listings-and-ads/actions/runs/4686389698
   - There is a warning in the **Annotations** block.
   - The warning comes from [this position](https://github.com/woocommerce/google-listings-and-ads/actions/runs/4686389698/jobs/8304425314#step:3:51)
      ![image](https://user-images.githubusercontent.com/17420811/231729203-796177e4-315d-4517-a0fb-8f08130260f5.png)
2. View the testing job that is temporarily targeted to the test build `actions-v1.4.1-pre` of this PR: https://github.com/woocommerce/google-listings-and-ads/actions/runs/4688047311
   - There should be no longer warnings in the **Annotations** block.
   - Check if the [dir](https://github.com/woocommerce/google-listings-and-ads/actions/runs/4688047311/jobs/8308093942?pr=1948#step:3:53) is passed correctly.
      ![2023-04-13 18 33 27](https://user-images.githubusercontent.com/17420811/231733375-deedc7b5-19fb-499b-a857-ac169880b22e.png)
