### PR TITLE
Fix the missed `jobs` and incorrect `uses` in the README of `get-release-notes` action

### DIFF
--- a/packages/js/github-actions/actions/get-release-notes/README.md
+++ b/packages/js/github-actions/actions/get-release-notes/README.md
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get release notes
         id: get-notes
-        uses: ./packages/js/github-actions/actions/get-release-notes
+        uses: woocommerce/grow/get-release-notes@actions-v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           tag-template: "v{version}"
@@ -90,7 +90,7 @@ jobs:
 
       - name: Get release notes
         id: get-notes
-        uses: ./packages/js/github-actions/actions/get-release-notes
+        uses: woocommerce/grow/get-release-notes@actions-v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           tag-template: "v{version}"
@@ -141,7 +141,7 @@ jobs:
 
       - name: Get release notes
         id: get-notes
-        uses: ./packages/js/github-actions/actions/get-release-notes
+        uses: woocommerce/grow/get-release-notes@actions-v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           tag-template: "v{version}"

--- a/packages/js/github-actions/actions/get-release-notes/README.md
+++ b/packages/js/github-actions/actions/get-release-notes/README.md
@@ -17,6 +17,7 @@ on:
     branches:
       - release/my-tool
 
+jobs:
   EchoRelease:
     name: Echo Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While reviewing #50, found a few mistakes in the `get-release-notes` action document. This PR fixes:
- The missed `jobs` key in an example.
- Fix the incorrect action URIs and tags of the `uses` in all examples.

### Detailed test instructions:

View the [get-release-notes/README](https://github.com/woocommerce/grow/blob/aebc841df86be499abd64ce3a764a9177f409561/packages/js/github-actions/actions/get-release-notes/README.md) to check for corrections.
