### PR TITLE
Add GH action for release PR & checklist

### DIFF
--- a/packages/js/github-actions/README.md
+++ b/packages/js/github-actions/README.md
@@ -12,6 +12,7 @@ Custom GitHub actions that help to composite GitHub workflows across the repos m
 - [`get-plugin-releases`](actions/get-plugin-releases) - Get latest releases versions from WordPress or from a plugin.
 - [`get-release-notes`](actions/get-release-notes) - Get release notes via GitHub, infer the next version and tag
 - [`phpcs-diff`](actions/phpcs-diff) - Run PHPCS to the changed lines of code, set error annotations to a pull request
+- [`prepare-extension-release`](actions/prepare-extension-release) - Create the release branch & PR with checklist
 - [`prepare-mysql`](actions/prepare-mysql) - Enable MySQL, handle authentication compatibility
 - [`prepare-node`](actions/prepare-node) - Set up Node.js with a specific version, load npm cache, install Node dependencies
 - [`prepare-php`](actions/prepare-php) - Set up PHP with a specific version and tools, load Composer cache, install Composer dependencies

--- a/packages/js/github-actions/actions/prepare-extension-release/README.md
+++ b/packages/js/github-actions/actions/prepare-extension-release/README.md
@@ -44,6 +44,3 @@ on:
           wc_version: ${{ github.event.inputs.wc_version }}
           main_branch: 'trunk'
 ```
-
-#### Checklist template
-

--- a/packages/js/github-actions/actions/prepare-extension-release/README.md
+++ b/packages/js/github-actions/actions/prepare-extension-release/README.md
@@ -1,0 +1,49 @@
+# Prepare Grow extension release
+
+This action provides the following functionality:
+
+- Creates a release branch
+- Creates a release PR with a checklist & full `woorelease` commands to run locally.
+
+## Usage
+
+See [action.yml](action.yml)
+
+#### Basic:
+
+```yaml
+name: 'Prepare New Release'
+run-name:  Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number to be released'
+        required: true
+      type:
+        description: 'Type of the release (release|hotfix)'
+        required: true
+        default: 'release'
+      wp_version:
+        description: 'WordPress tested up to'
+      wc_version:
+        description: 'WooCommerce tested up to'
+
+  Prepare_release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: woocommerce/grow/prepare-extension-release@actions-v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          type: ${{ github.event.inputs.type }}
+          wp_version: ${{ github.event.inputs.wp_version }}
+          wc_version: ${{ github.event.inputs.wc_version }}
+          main_branch: 'trunk'
+```
+
+#### Checklist template
+

--- a/packages/js/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/js/github-actions/actions/prepare-extension-release/action.yml
@@ -1,0 +1,75 @@
+name: Prepare extension release
+description: Create the release branch & PR with checklist.
+
+inputs:
+  version:
+    description: 'Version number to be released'
+    required: true
+  type:
+    description: 'Type of the release (release|hotfix)'
+    required: true
+    default: 'release'
+  wp_version:
+    description: 'WordPress tested up to'
+  wc_version:
+    description: 'WooCommerce tested up to'
+  main_branch:
+    description: 'Where release branches are merged'
+    required: true
+    default: 'trunk'
+
+outputs:
+  release-notes:
+    description: The content of release notes.
+
+  release-notes-shell:
+    description: The escaped "release-notes" for use in the shell.
+
+  release-changelog:
+    description: The changelog part in release notes.
+
+  release-changelog-shell:
+    description: The escaped "release-changelog" for use in the shell.
+
+  next-version:
+    description: The next version inferred via the release notes. For example, 2.0.0, 1.5.0 or 1.4.8.
+
+  next-tag:
+    description: The next tag name inferred via the release notes. For example, 2.0.0, v1.5.0 or my-tool-v1.4.8.
+
+runs:
+  using: composite
+  steps:
+    - name: Set release branch name
+      id: release-vars
+      shell: bash
+      run: echo "branch=${{ inputs.type }}/${{ inputs.version }}" >> $GITHUB_OUTPUT
+
+    - name: Prepare release commits
+      shell: bash
+       # Use the github-actions bot account to commit.
+       # https://api.github.com/users/github-actions%5Bbot%5D
+      run: |
+        git config user.name github-actions[bot]
+        git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+        git checkout -b ${{ steps.release-vars.outputs.branch }}
+
+        git commit --allow-empty -q -m "Start \`${{ steps.release-vars.outputs.branch }}\`."
+        git push --set-upstream origin ${{ steps.release-vars.outputs.branch }}
+    - name: Create a pull request for the release
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const action_path = '${{ github.action_path }}';
+          const { default: script } = await import( `${ action_path }/woo-extension-create-pr-for-release.mjs` );
+          await script( {
+            github,
+            context,
+            base: '${{ inputs.main_branch }}',
+            repository: '${{ github.repository }}',
+            refName: '${{ steps.release-vars.outputs.branch }}',
+            type: '${{ inputs.type }}',
+            version: '${{ inputs.version }}',
+            wpVersion: '${{ inputs.wp_version }}',
+            wcVersion: '${{ inputs.wc_version }}'
+          } );

--- a/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -39,15 +39,14 @@ export default async ( {
    1. [ ] Run a few basic smoke tests
 
 ## Next steps
-1. ~Approve this PR to allow the next workflow to create an actual release.~
 1. [ ] Do the final release
    \`\`\`
    woorelease release --product_version=${ version } ${ testedVersions }  --generate_changelog ${ repoURL }
    \`\`\`
    When prompted for changelog entries, double-check and apply any changes if needed.
-1. ~Another workflow will pick up the new release and post a comment here with GitHub's release notes, merge the PR, and merge \`trunk\` to \`develop\`.~
 1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.
 1. [ ] Merge this PR after the new release is successfully created and the version tags are updated.
+1. [ ] Merge \`trunk\` to \`develop\` (if applicable for this repo).
 `;
 
 	await github.rest.pulls.create( {

--- a/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -1,0 +1,60 @@
+export default async ( {
+	github,
+	context,
+	base,
+	refName,
+	type,
+	version,
+	wpVersion,
+	wcVersion,
+} ) => {
+	// Assume the extension package is named as the repo.
+	const extensionPackageName = context.payload.repository.name;
+	// Build repo URL. WooRelease expects HTML one with `https://github.com/…/tree…`.
+	const repoURL =
+		context.payload.repository.html_url + '/tree/' + type + '/' + version;
+
+	const testedVersions =
+		( wpVersion ? ' --wp_tested=' + wpVersion : '' ) +
+		( wcVersion ? ' --wc_tested=' + wcVersion : '' );
+
+	const title = `${ type } ${ version }`;
+	const body = `## Checklist
+1. [ ] Check if the version, base, and target branches are as you desire.
+1. [ ] Make sure you have \`woorelease\` installed and set up.
+1. [ ] Simulate the release locally
+   \`\`\`sh
+   git fetch origin ${ refName }
+   git checkout ${ refName }
+   woorelease simulate --product_version=${ version } ${ testedVersions } --generate_changelog ${ repoURL }
+   \`\`\`
+   _Note: Select \`y\` when prompted: "Would you like to add/delete them in the svn working copy?"_
+1. [ ] The changelog is correct.
+   Check if some entries are missing, need rewording, or need to be deleted. You can edit respective PRs by changing their title, \`### Changelog entry\` section, or assigning the \`changelog: none\` label.
+   You can also edit the changelog manually in the \`woorelease release\` step later.
+1. [ ] Automated tests are passing.
+1. [ ] Test the package
+   1. [ ] Install the \`/tmp/${ extensionPackageName }.zip\` file on a test site
+   1. [ ] Confirm it activates without warnings/errors and is showing the right versions
+   1. [ ] Run a few basic smoke tests
+
+## Next steps
+1. ~Approve this PR to allow the next workflow to create an actual release.~
+1. [ ] Do the final release
+   \`\`\`
+   woorelease release --product_version=${ version } ${ testedVersions }  --generate_changelog ${ repoURL }
+   \`\`\`
+   When prompted for changelog entries, double-check and apply any changes if needed.
+1. ~Another workflow will pick up the new release and post a comment here with GitHub's release notes, merge the PR, and merge \`trunk\` to \`develop\`.~
+1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.
+1. [ ] Merge this PR after the new release is successfully created and the version tags are updated.
+`;
+
+	await github.rest.pulls.create( {
+		...context.repo,
+		base,
+		head: refName,
+		title,
+		body,
+	} );
+};

--- a/packages/js/github-actions/rollup.config.js
+++ b/packages/js/github-actions/rollup.config.js
@@ -84,4 +84,17 @@ export default [
 			json( { compact: true } ),
 		],
 	},
+	{
+		input: './actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs',
+		output: {
+			file: './actions/prepare-extension-release/woo-extension-create-pr-for-release.mjs',
+		},
+		plugins: [
+			nodeResolve( {
+				preferBuiltins: true,
+				exportConditions: [ 'node' ],
+			} ),
+			json( { compact: true } ),
+		],
+	},
 ];


### PR DESCRIPTION
_This is a continuation of https://github.com/woocommerce/automatewoo/pull/1404_
### Changes proposed in this Pull Request:

Adds a new GitHub Action to prepare extension release.

To be used with a manual GH workflow. It takes versions, then starts a branch and creates a PR with the checklist.
The aim is to automate and unify the release process across our repos.


### Screenshots:

![image](https://user-images.githubusercontent.com/17435/233470959-7affcc0a-201d-49c7-9172-ae993bb055ea.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Add a workflow in another repo following the instructions from `packages/js/github-actions/actions/prepare-extension-release/README.md`, replacing `woocommerce/grow/prepare-extension-release@actions-v1` with `woocommerce/grow/prepare-extension-release@actions-v1.5.2-pre` as this PR is not yet released.

   Like https://github.com/tomalec/grow/blob/391113cd2a00bac2dc808674ecebdb30e8fd83da/.github/workflows/extension-release.yml
2. Run the created workflow. 

### Additional details:

The further improvements automation I was trying to implement but didn't finish:
1. (tricky) Make the workflow run `woorelease simulate`. So we could reduce two more manual steps for the developer, and serve them just a `.zip` package to smoke test & changelog to inspect. It's tricky, as requires setting up all woorelease keys on GHA, and makes the simulation repo harder to inspect.
2. (tricky) Make another workflow pick up the approval, and make the actual release. The tricky part is as above. But it may mitigate a few more issues we were experiencing in the past, as it could assert the consistent build environment (node, npm, composer versions)
3. (easier) Make another workflow pick up a release, then 
   1. publish the GitHub's release notes as a comment to matching PR,
   2. merge the PR to `trunk`
   3. merge `trunk` to `develop`

Further improvements I envision:
1. Allow bumping version by just `major|minor|patch` instead of typing a full version
2. Allow customizing checklist, so some repos could have a few more specific steps


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Extension release preparation github-action.
