### PR TITLE
Add pre- & post-steps to extension release PR

### DIFF
--- a/packages/js/github-actions/actions/prepare-extension-release/README.md
+++ b/packages/js/github-actions/actions/prepare-extension-release/README.md
@@ -30,8 +30,9 @@ on:
       wc-version:
         description: 'WooCommerce tested up to'
 
+jobs:
   Prepare_release:
-    name: Prepare release
+    name: 'Prepare release'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/packages/js/github-actions/actions/prepare-extension-release/README.md
+++ b/packages/js/github-actions/actions/prepare-extension-release/README.md
@@ -25,9 +25,9 @@ on:
         description: 'Type of the release (release|hotfix)'
         required: true
         default: 'release'
-      wp_version:
+      wp-version:
         description: 'WordPress tested up to'
-      wc_version:
+      wc-version:
         description: 'WooCommerce tested up to'
 
   Prepare_release:
@@ -40,7 +40,7 @@ on:
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}
-          wp_version: ${{ github.event.inputs.wp_version }}
-          wc_version: ${{ github.event.inputs.wc_version }}
-          main_branch: 'trunk'
+          wp-version: ${{ github.event.inputs.wp-version }}
+          wc-version: ${{ github.event.inputs.wc-version }}
+          main-branch: 'trunk'
 ```

--- a/packages/js/github-actions/actions/prepare-extension-release/README.md
+++ b/packages/js/github-actions/actions/prepare-extension-release/README.md
@@ -43,4 +43,10 @@ on:
           wp-version: ${{ github.event.inputs.wp-version }}
           wc-version: ${{ github.event.inputs.wc-version }}
           main-branch: 'trunk'
+          pre-steps: |
+            1. [ ] Prepare something more before the release
+          post-steps: |
+            ### Additional post-release checklist
+            1. [ ] Update documentation
+               - [ ] Publish any new required docs
 ```

--- a/packages/js/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/js/github-actions/actions/prepare-extension-release/action.yml
@@ -25,23 +25,12 @@ inputs:
     default: ''
 
 outputs:
-  release-notes:
-    description: The content of release notes.
-
-  release-notes-shell:
-    description: The escaped "release-notes" for use in the shell.
-
-  release-changelog:
-    description: The changelog part in release notes.
-
-  release-changelog-shell:
-    description: The escaped "release-changelog" for use in the shell.
-
-  next-version:
-    description: The next version inferred via the release notes. For example, 2.0.0, 1.5.0 or 1.4.8.
-
-  next-tag:
-    description: The next tag name inferred via the release notes. For example, 2.0.0, v1.5.0 or my-tool-v1.4.8.
+  branch-name:
+    description: "Branch name"
+    value: ${{ steps.release-vars.outputs.branch }}
+  pr:
+    description: "Pull request"
+    value: ${{ steps.prepare-release-pr.outputs.result }}
 
 runs:
   using: composite
@@ -71,9 +60,15 @@ runs:
           const inputs = ${{ toJSON(inputs) }};
 
           const { default: script } = await import( `${ action_path }/woo-extension-create-pr-for-release.mjs` );
-          await script( {
+          return await script( {
             context,
             github,
             inputs,
             refName: '${{ steps.release-vars.outputs.branch }}'
           } );
+    - name: Generate summary
+      shell: bash
+      run: |
+        echo "Release PR created at ${{  fromJSON(steps.prepare-release-pr.outputs.result).html_url }}" >> $GITHUB_STEP_SUMMARY
+
+

--- a/packages/js/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/js/github-actions/actions/prepare-extension-release/action.yml
@@ -9,11 +9,11 @@ inputs:
     description: 'Type of the release (release|hotfix)'
     required: true
     default: 'release'
-  wp_version:
+  wp-version:
     description: 'WordPress tested up to'
-  wc_version:
+  wc-version:
     description: 'WooCommerce tested up to'
-  main_branch:
+  main-branch:
     description: 'Where release branches are merged'
     required: true
     default: 'trunk'
@@ -57,19 +57,17 @@ runs:
         git commit --allow-empty -q -m "Start \`${{ steps.release-vars.outputs.branch }}\`."
         git push --set-upstream origin ${{ steps.release-vars.outputs.branch }}
     - name: Create a pull request for the release
+      id: prepare-release-pr
       uses: actions/github-script@v6
       with:
         script: |
           const action_path = '${{ github.action_path }}';
+          const inputs = ${{ toJSON(inputs) }};
+
           const { default: script } = await import( `${ action_path }/woo-extension-create-pr-for-release.mjs` );
           await script( {
-            github,
             context,
-            base: '${{ inputs.main_branch }}',
-            repository: '${{ github.repository }}',
-            refName: '${{ steps.release-vars.outputs.branch }}',
-            type: '${{ inputs.type }}',
-            version: '${{ inputs.version }}',
-            wpVersion: '${{ inputs.wp_version }}',
-            wcVersion: '${{ inputs.wc_version }}'
+            github,
+            inputs,
+            refName: '${{ steps.release-vars.outputs.branch }}'
           } );

--- a/packages/js/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/js/github-actions/actions/prepare-extension-release/action.yml
@@ -17,6 +17,12 @@ inputs:
     description: 'Where release branches are merged'
     required: true
     default: 'trunk'
+  pre-steps:
+    description: 'Additional steps to be added before running woorelease'
+    default: ''
+  post-steps:
+    description: 'Additional steps to be added after running woorelease'
+    default: ''
 
 outputs:
   release-notes:

--- a/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -1,13 +1,11 @@
-export default async ( {
-	github,
-	context,
-	base,
-	refName,
-	type,
-	version,
-	wpVersion,
-	wcVersion,
-} ) => {
+export default async ( { context, github, inputs, refName } ) => {
+	const {
+		'main-branch': base,
+		type,
+		version,
+		'wc-version': wcVersion,
+		'wp-version': wpVersion,
+	} = inputs;
 	// Assume the extension package is named as the repo.
 	const extensionPackageName = context.payload.repository.name;
 	// Build repo URL. WooRelease expects HTML one with `https://github.com/…/tree…`.

--- a/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -1,6 +1,8 @@
 export default async ( { context, github, inputs, refName } ) => {
 	const {
 		'main-branch': base,
+		'post-steps': postSteps,
+		'pre-steps': preSteps,
 		type,
 		version,
 		'wc-version': wcVersion,
@@ -17,9 +19,15 @@ export default async ( { context, github, inputs, refName } ) => {
 		( wcVersion ? ' --wc_tested=' + wcVersion : '' );
 
 	const title = `${ type } ${ version }`;
+	// We need to add only one newline before the pre-steps to make sure it's rendered as a list.
+	let trimmedPreSteps = preSteps;
+	if ( trimmedPreSteps !== '' ) {
+		trimmedPreSteps = '\n' + trimmedPreSteps.trim();
+	}
+
 	const body = `## Checklist
 1. [ ] Check if the version, base, and target branches are as you desire.
-1. [ ] Make sure you have \`woorelease\` installed and set up.
+1. [ ] Make sure you have \`woorelease\` installed and set up.${ trimmedPreSteps }
 1. [ ] Simulate the release locally
    \`\`\`sh
    git fetch origin ${ refName }
@@ -45,6 +53,7 @@ export default async ( { context, github, inputs, refName } ) => {
 1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.
 1. [ ] Merge this PR after the new release is successfully created and the version tags are updated.
 1. [ ] Merge \`trunk\` to \`develop\` (if applicable for this repo).
+${ postSteps }
 `;
 
 	await github.rest.pulls.create( {

--- a/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -27,11 +27,14 @@ export default async ( { context, github, inputs, refName } ) => {
 
 	const body = `## Checklist
 1. [ ] Check if the version, base, and target branches are as you desire.
-1. [ ] Make sure you have \`woorelease\` installed and set up.${ trimmedPreSteps }
-1. [ ] Simulate the release locally
+1. [ ] Make sure you have \`woorelease\` installed and set up.
+1. [ ] Go to your local repo clone, and check out this PR to be able to commit any potential adjustments.
    \`\`\`sh
    git fetch origin ${ refName }
    git checkout ${ refName }
+   \`\`\`${ trimmedPreSteps }
+1. [ ] Simulate the release locally
+   \`\`\`sh
    woorelease simulate --product_version=${ version } ${ testedVersions } --generate_changelog ${ repoURL }
    \`\`\`
    _Note: Select \`y\` when prompted: "Would you like to add/delete them in the svn working copy?"_

--- a/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/js/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -56,11 +56,12 @@ export default async ( { context, github, inputs, refName } ) => {
 ${ postSteps }
 `;
 
-	await github.rest.pulls.create( {
+	const pull = await github.rest.pulls.create( {
 		...context.repo,
 		base,
 		head: refName,
 		title,
 		body,
 	} );
+	return pull.data;
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [Rename prepare-extension-release inputs to kebabcase,](https://github.com/woocommerce/grow/pull/58/commits/0cf5cb5d97395e76b7131a4df0c7a02456a745c4) 
   to follow the convention of other actions.
   Read them as JSON.
- [Add pre- & post-steps inputs,](https://github.com/woocommerce/grow/pull/58/commits/35882f69ff6e5d7bd075a2607dd1d6b514e45e53) 
   to be able to customize a little the release proces per each consuming repo.
- [Return outputs, generate a summary](https://github.com/woocommerce/grow/pull/58/commits/1d06aca71023fceac8f0a6c40bac81f1d3bde6fe) 
   with a link to the created PR.


### Screenshots:
![image](https://github.com/woocommerce/grow/assets/17435/d7e88379-09da-45b9-88cb-8adb713be469)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make a workflow that uses `woocommerce/grow/prepare-extension-release@actions-v1.6.1-pre`, its results, and  `pre-`, `post-steps`,
   like https://github.com/tomalec/grow/blob/a1a62cfb29783d9636576bfb354a557254529414/.github/workflows/extension-release.yml#L36-L70
3. [Run that workflow](https://github.com/tomalec/grow/actions/runs/5214987470)
4. Check that workflow has a PR link in the summary
5. Check that the resulting PR has additional steps https://github.com/tomalec/grow/pull/33


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add `pre-` & `post-steps` to `prepare-extension-release` action, return some outputs.
