### PR TITLE
Add a new GH custom action for publishing or updating the extension development build via a pre-release on GitHub

### DIFF
--- a/packages/js/github-actions/README.md
+++ b/packages/js/github-actions/README.md
@@ -16,6 +16,7 @@ Custom GitHub actions that help to composite GitHub workflows across the repos m
 - [`prepare-mysql`](actions/prepare-mysql) - Enable MySQL, handle authentication compatibility
 - [`prepare-node`](actions/prepare-node) - Set up Node.js with a specific version, load npm cache, install Node dependencies
 - [`prepare-php`](actions/prepare-php) - Set up PHP with a specific version and tools, load Composer cache, install Composer dependencies
+- [`publish-extension-dev-build`](actions/publish-extension-dev-build) - Publish extension development build
 - [`stylelint-annotation`](actions/stylelint-annotation) - Annotate stylelint results via stylelint formatter
 - [`update-version-tags`](actions/update-version-tags) - Update version tags
 - [`hook-documentation`](/packages/php/github-actions/hook-documentation) - Generate WordPress hook documentation

--- a/packages/js/github-actions/actions/publish-extension-dev-build/README.md
+++ b/packages/js/github-actions/actions/publish-extension-dev-build/README.md
@@ -1,0 +1,31 @@
+# Publish extension development build
+
+This action provides the following functionality for GitHub Actions users:
+
+- Publish or update the extension development build via a pre-release on GitHub.
+
+## Usage
+
+See [action.yml](action.yml)
+
+#### Basic:
+
+```yaml
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  PublishDevBuild:
+    name: Publish Dev Build
+    runs-on: ubuntu-latest
+    steps:
+      # build extension
+      - run: npm run build
+
+      - uses: woocommerce/grow/publish-extension-dev-build@actions-v1
+        with:
+          extension-asset-path: my-extension.zip
+
+```

--- a/packages/js/github-actions/actions/publish-extension-dev-build/action.yml
+++ b/packages/js/github-actions/actions/publish-extension-dev-build/action.yml
@@ -1,0 +1,58 @@
+name: Publish extension development build
+description: Publish or update the extension development build via a pre-release on GitHub
+
+inputs:    
+  extension-asset-path:
+    description: The extension asset path to find the existing asset for replacement or to upload. It will use the filename to match assets in the target release when finding.
+    required: true
+
+  extension-asset-content-type:
+    description: The "Content-Type" HTTP header field indicates the media type of the extension asset.
+    default: "application/zip"
+
+  tag-name:
+    description: The tag name to find the existing release for replacement or to create a release.
+    default: "gha-dev-build"
+
+  release-title:
+    description: The release title.
+    default: "Latest devlopment build"
+
+runs:
+  using: composite
+  steps:
+    # Get unreleased notes
+    - id: unreleased-notes
+      uses: woocommerce/grow/get-release-notes@actions-v1
+      with:
+        repo-token: ${{ github.token }}
+        tag-template: "{version}"
+
+    # Publish the build to GitHub
+    - uses: actions/github-script@v6
+      with:
+        # The main action inputs are not accessible within the "script" input of actions/github-script.
+        # So it needs to do forwarding.
+        script: |
+          const actionPath = '${{ github.action_path }}';
+          const { default: script } = await import( `${ actionPath }/publish-extension-dev-build.mjs` );
+
+          const { 'release-changelog': changelog } = ${{ toJSON( steps.unreleased-notes.outputs ) }};
+          const inputs = ${{ toJSON( inputs ) }};
+
+          if ( ! inputs[ 'extension-asset-path' ] ) {
+            core.setFailed( 'Input required and not supplied: extension-asset-path' );
+            return;
+          }
+
+          inputs[ 'extension-asset-content-type' ] ??= 'application/zip';
+          inputs[ 'tag-name' ] ??= 'gha-dev-build';
+          inputs[ 'release-title' ] ??= 'Latest devlopment build';
+
+          await script( {
+            github,
+            context,
+            core,
+            changelog,
+            inputs,
+          } );

--- a/packages/js/github-actions/actions/publish-extension-dev-build/src/publish-extension-dev-build.js
+++ b/packages/js/github-actions/actions/publish-extension-dev-build/src/publish-extension-dev-build.js
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import handleActionErrors from '../../../utils/handle-action-errors';
+
+export default async ( { github, context, core, changelog, inputs } ) => {
+	const { repos, git } = github.rest;
+
+	const assetPath = inputs[ 'extension-asset-path' ];
+	const assetContentType = inputs[ 'extension-asset-content-type' ];
+	const tag = inputs[ 'tag-name' ];
+	const releaseTitle = inputs[ 'release-title' ];
+
+	async function findExistingRelease() {
+		core.info( `Finding the existing release by tag ${ tag } …` );
+
+		return repos
+			.getReleaseByTag( {
+				...context.repo,
+				tag,
+			} )
+			.then( ( response ) => {
+				const { id, assets } = response.data;
+
+				core.info(
+					'Found the target tag. Proceed to update the existing release.'
+				);
+				return { id, assets };
+			} )
+			.catch( ( error ) => {
+				if ( error.status === 404 ) {
+					core.info(
+						'The target tag is not found. Proceed to create a new release.'
+					);
+					return {};
+				}
+				return Promise.reject( error );
+			} );
+	}
+
+	async function publishRelease( { id, assets } ) {
+		core.info( 'Publishing release …' );
+
+		const updateTime = new Date().toUTCString();
+		const body = `## Unreleased changes - ${ updateTime }\n${ changelog }`;
+		const params = {
+			...context.repo,
+			name: releaseTitle,
+			body,
+			prerelease: true,
+			make_latest: 'false',
+		};
+
+		const isExisting = Boolean( id );
+
+		if ( isExisting ) {
+			params.release_id = id;
+		} else {
+			params.tag_name = tag;
+			params.target_commitish = context.ref.replace( 'refs/heads/', '' );
+		}
+
+		const apiName = isExisting ? 'updateRelease' : 'createRelease';
+		const response = await repos[ apiName ]( params );
+
+		return {
+			id: response.data.id,
+			assets,
+		};
+	}
+
+	async function updateExtensionAsset( { id, assets = [] } ) {
+		const extensionName = path.basename( assetPath );
+		const extensionAsset = assets.find(
+			( asset ) => asset.name === extensionName
+		);
+
+		if ( extensionAsset ) {
+			core.info( 'Deleting the existing extension asset …' );
+
+			await repos.deleteReleaseAsset( {
+				...context.repo,
+				asset_id: extensionAsset.id,
+			} );
+		}
+
+		core.info( 'Updating the extension asset …' );
+
+		return await repos.uploadReleaseAsset( {
+			...context.repo,
+			headers: {
+				'content-type': assetContentType,
+				'content-length': fs.statSync( assetPath ).size,
+			},
+			release_id: id,
+			name: extensionName,
+			data: fs.readFileSync( assetPath ),
+		} );
+	}
+
+	async function updateTag() {
+		core.info( `Updating the ref of tag ${ tag } to ${ context.sha } …` );
+
+		return git.updateRef( {
+			...context.repo,
+			force: true,
+			ref: `tags/${ tag }`,
+			sha: context.sha,
+		} );
+	}
+
+	return Promise.resolve()
+		.then( findExistingRelease )
+		.then( publishRelease )
+		.then( updateExtensionAsset )
+		.then( updateTag )
+		.catch( handleActionErrors );
+};

--- a/packages/js/github-actions/rollup.config.js
+++ b/packages/js/github-actions/rollup.config.js
@@ -97,4 +97,17 @@ export default [
 			json( { compact: true } ),
 		],
 	},
+	{
+		input: './actions/publish-extension-dev-build/src/publish-extension-dev-build.js',
+		output: {
+			file: './actions/publish-extension-dev-build/publish-extension-dev-build.mjs',
+		},
+		plugins: [
+			nodeResolve( {
+				preferBuiltins: true,
+				exportConditions: [ 'node' ],
+			} ),
+			commonjs(),
+		],
+	},
 ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This GH custom action comes from the Grow Engineers HACK Day activity.

The idea is to keep collaborators informed of what contents are coming but not yet released at any time, and to be the latest test build for download, without waiting for developers to build one.

In particular, it might help with the mentioned question of collaboration with our Product Ambassador: “What process can we put in place to help remind us to get the Product Ambassador involved at an early stage?”

Ref: peeuvX-AL-p2

### Detailed test instructions:

💡 Take [Google Listings & Ads extension](https://github.com/woocommerce/google-listings-and-ads) as a practical use case.

1. View the workflow job logs: https://github.com/woocommerce/google-listings-and-ads/actions/runs/5277027865
2. View the published release for the `develop` branch: https://github.com/woocommerce/google-listings-and-ads/releases/tag/gha-dev-build
3. View how the workflow was configured: https://github.com/woocommerce/google-listings-and-ads/pull/1988
