### PR TITLE
Add a missed backtick in the main README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The packages here are too experimental or too Grow-specific to be shared Woo-wid
 
 ## List of plugins
 
-- [`/plugins/grow-smooth-generator](plugins/grow-smooth-generator/README.md) - A smooth generator for Grow extension data
+- [`/plugins/grow-smooth-generator`](plugins/grow-smooth-generator/README.md) - A smooth generator for Grow extension data
 
 ## List of configs
 - [`/configs/woocommerce-github-sync-labels`](configs/woocommerce-github-sync-labels/README.md) - Config to add extra labels to Grow's repositories.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix a missed backtick:

![image](https://github.com/woocommerce/grow/assets/17420811/d32956bd-1c1b-452d-b863-14606bcfbc5d)

### Detailed test instructions:

View the [README.md](https://github.com/woocommerce/grow/blob/75ea3bf30b94d36b8738b9ce99c93903dd385151/README.md) file.
