### PR TITLE
Add automerge-released-trunk action

### DIFF
--- a/packages/github-actions/actions/automerge-released-trunk/README.md
+++ b/packages/github-actions/actions/automerge-released-trunk/README.md
@@ -24,6 +24,5 @@ jobs:
   automerge_trunk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - uses: woocommerce/grow/automerge-released-trunk@actions-v1
 ```

--- a/packages/github-actions/actions/automerge-released-trunk/README.md
+++ b/packages/github-actions/actions/automerge-released-trunk/README.md
@@ -1,0 +1,29 @@
+# Auto merge a released trunk
+
+This action provides the following functionality for GitHub Actions users:
+
+- Automatically merge trunk to develop after a release done with the `woocommerce/grow/prepare-extension-release`
+
+## Usage
+
+See [action.yml](action.yml)
+
+#### Basic:
+
+```yaml
+name: Auto merge a released trunk
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - trunk
+
+jobs:
+  automerge_trunk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: woocommerce/grow/automerge-released-trunk@actions-v1
+```

--- a/packages/github-actions/actions/automerge-released-trunk/action.yml
+++ b/packages/github-actions/actions/automerge-released-trunk/action.yml
@@ -4,6 +4,8 @@ description: Automatically merge trunk to develop after a release.
 runs:
   using: composite
   steps:
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: "Merge the release to develop"
       shell: bash
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}

--- a/packages/github-actions/actions/automerge-released-trunk/action.yml
+++ b/packages/github-actions/actions/automerge-released-trunk/action.yml
@@ -12,8 +12,7 @@ runs:
       run: |
         git config user.name github-actions[bot]
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch origin develop trunk --unshallow
+        git fetch origin develop trunk --unshallow --no-tags
         git checkout develop
-        git pull
         git merge --no-ff origin/trunk -m "Automerge ${{ github.head_ref }} from trunk to develop"
         git push

--- a/packages/github-actions/actions/automerge-released-trunk/action.yml
+++ b/packages/github-actions/actions/automerge-released-trunk/action.yml
@@ -1,0 +1,19 @@
+name: Auto merge a released trunk
+description: Automatically merge trunk to develop after a release.
+
+runs:
+  using: composite
+  steps:
+    - name: "Merge the release to develop"
+      shell: bash
+      if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}
+      # Use the github-actions bot account to commit.
+      # https://api.github.com/users/github-actions%5Bbot%5D
+      run: |
+        git config user.name github-actions[bot]
+        git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+        git fetch origin develop trunk --unshallow
+        git checkout develop
+        git pull
+        git merge --no-ff origin/trunk -m "Automerge ${{ github.head_ref }} from trunk to develop"
+        git push


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Add automerge-released-trunk action to automatically merge trunk to develop after a release done by `woocommerce/grow/prepare-extension-release`.

To avoid the need of manual work like, this https://github.com/woocommerce/automatewoo-referrals/pull/214#event-9859183599


### Screenshots:

![image](https://github.com/woocommerce/grow/assets/17435/7680b55f-98af-4631-b5d4-8a3bcbfde83d)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a test repo that has the ``woocommerce/grow/prepare-extension-release`` set up.
2. Add to trunk another workflow following the README https://github.com/woocommerce/grow/compare/add/automerge-action?expand=1#diff-55cb289fd53c554abe94cee8c99554f02791a3d60ba513f6fdb28c90625fd238 but with the prereleased version `actions-v1.8.1-pre`
```yml
name: 'Merge the release to develop'
run-name:  Merge the released `${{ github.head_ref }}` from `trunk` to `develop`

on:
  pull_request:
    types:
      - closed
    branches:
      - trunk

jobs:
  automerge_trunk:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: woocommerce/grow/automerge-released-trunk@actions-v1.8.1-pre
```
3. Create a develop branch
4. Create a release with ``woocommerce/grow/prepare-extension-release``. Then merge it - check that  `trunk` gets merged to `develop`. Like
   - https://github.com/tomalec/grow/pull/25
   - https://github.com/tomalec/grow/actions/runs/5611581454/jobs/10268246971
   - https://github.com/tomalec/grow/commit/e3df2a5a99565cfd2fd68349275f94ea6f8e6983
5. Create a release with ``woocommerce/grow/prepare-extension-release``, switch a target branch to something else. Merge the PR. Nothing should get merged to develop
5. Create a release with ``woocommerce/grow/prepare-extension-release``, close it without merging. Nothing should get merged to develop
6. Create a PR with `release/1.2.3` as a regular user, then merge it to trunk. Nothing should get merged to develop


### Additional details:
1. `hotfix` branches are not automerged, as sometimes it may not be desired. Like, if the current develop at `2.3.4` and we are releasing `1.2.7` with something that is no longer relevant to `2.3`
2. We can consider specifying `trunk` and `develop` branch names as inputs, as well as github bot user name. But I went YAGNI here. Let's try to simplify and unify our workflows instead of making every repo a unique snowflake. To reduce overall code and docs size.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - `automerge-released-trunk` action.
