### PR TITLE
Remove `trunk`->`develop` merge step from the release checklist of `automerge-released-trunk` action

### DIFF
--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -55,7 +55,6 @@ export default async ( { context, github, inputs, refName } ) => {
    When prompted for changelog entries, double-check and apply any changes if needed.
 1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.
 1. [ ] Merge this PR after the new release is successfully created and the version tags are updated.
-1. [ ] Merge \`trunk\` to \`develop\` (if applicable for this repo).
 ${ postSteps }
 `;
 


### PR DESCRIPTION
This is a follow-up for https://github.com/woocommerce/grow/pull/64

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Remove trunk->develop merge from release checklist
This step will be automatically covered by woocommerce/grow/automerge-released-trunk


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Review the steps in https://github.com/woocommerce/grow/compare/fix/checklist-pr-automerge?expand=1#diff-4d854c0b5c65e4ad587b12c84b307cd46b76fb57dc662edd107e75f190036177


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Remove trunk->develop merge step from the release checklist
