### PR TITLE
Capitalized title of release PR

### DIFF
--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -18,7 +18,9 @@ export default async ( { context, github, inputs, refName } ) => {
 		( wpVersion ? ' --wp_tested=' + wpVersion : '' ) +
 		( wcVersion ? ' --wc_tested=' + wcVersion : '' );
 
-	const title = `${ type.charAt( 0 ).toUpperCase() + type.slice( 1 ) } ${ version }`;
+	const title = `${ 
+		type.charAt( 0 ).toUpperCase() + type.slice( 1 ) 
+	} ${ version }`;
 	// We need to add only one newline before the pre-steps to make sure it's rendered as a list.
 	let trimmedPreSteps = preSteps;
 	if ( trimmedPreSteps !== '' ) {

--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -18,7 +18,7 @@ export default async ( { context, github, inputs, refName } ) => {
 		( wpVersion ? ' --wp_tested=' + wpVersion : '' ) +
 		( wcVersion ? ' --wc_tested=' + wcVersion : '' );
 
-	const title = `${ type } ${ version }`;
+	const title = `${ type.charAt(0).toUpperCase() + type.slice(1) } ${ version }`;
 	// We need to add only one newline before the pre-steps to make sure it's rendered as a list.
 	let trimmedPreSteps = preSteps;
 	if ( trimmedPreSteps !== '' ) {

--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -18,8 +18,8 @@ export default async ( { context, github, inputs, refName } ) => {
 		( wpVersion ? ' --wp_tested=' + wpVersion : '' ) +
 		( wcVersion ? ' --wc_tested=' + wcVersion : '' );
 
-	const title = `${ 
-		type.charAt( 0 ).toUpperCase() + type.slice( 1 ) 
+	const title = `${
+		type.charAt( 0 ).toUpperCase() + type.slice( 1 )
 	} ${ version }`;
 	// We need to add only one newline before the pre-steps to make sure it's rendered as a list.
 	let trimmedPreSteps = preSteps;

--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -18,7 +18,7 @@ export default async ( { context, github, inputs, refName } ) => {
 		( wpVersion ? ' --wp_tested=' + wpVersion : '' ) +
 		( wcVersion ? ' --wc_tested=' + wcVersion : '' );
 
-	const title = `${ type.charAt(0).toUpperCase() + type.slice(1) } ${ version }`;
+	const title = `${ type.charAt( 0 ).toUpperCase() + type.slice( 1 ) } ${ version }`;
 	// We need to add only one newline before the pre-steps to make sure it's rendered as a list.
 	let trimmedPreSteps = preSteps;
 	if ( trimmedPreSteps !== '' ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As discussed in https://github.com/woocommerce/pinterest-for-woocommerce/pull/788#pullrequestreview-1543199694, this PR capitalizes the name of the release PR created by the `Prepare New Release` workflow.

### Detailed test instructions:
1. Add a workflow in another repo following the instructions from `packages/js/github-actions/actions/prepare-extension-release/README.md`, replacing `woocommerce/grow/prepare-extension-release@actions-v1` with `woocommerce/grow/prepare-extension-release@actions-v1.5.2-pre` as this PR is not yet released.

   Like https://github.com/tomalec/grow/blob/391113cd2a00bac2dc808674ecebdb30e8fd83da/.github/workflows/extension-release.yml
2. Run the created workflow. 
3. Confirm that the title of the release is capitalized (e.g., `Release` instead of `release` or `Hotfix` instead of `hotfix`.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Capitalize release PR title.
