### PR TITLE
Add merge-trunk-develop-pr action

### DIFF
--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -6,12 +6,14 @@ Custom GitHub actions that help to composite GitHub workflows across the repos m
 
 ## Actions list
 
+- [`automerge-released-trunk`](actions/automerge-released-trunk) - Merge `trunk` to `develop` after an extension release
 - [`branch-label`](actions/branch-label) - Set PR labels according to the branch name
 - [`coverage-report`](actions/coverage-report) - Add a clover coverage report as a PR comment
 - [`eslint-annotation`](actions/eslint-annotation) - Annotate eslint results via eslint formatter
 - [`get-plugin-releases`](actions/get-plugin-releases) - Get latest releases versions from WordPress or from a plugin.
 - [`get-release-notes`](actions/get-release-notes) - Get release notes via GitHub, infer the next version and tag
 - [`hook-documentation`](actions/hook-documentation) - Generate WordPress hook documentation
+- [`merge-trunk-develop-pr`](actions/merge-trunk-develop-pr) - Create a PR to merge `trunk` to `develop` after an extension release
 - [`phpcs-diff`](actions/phpcs-diff) - Run PHPCS to the changed lines of code, set error annotations to a pull request
 - [`prepare-extension-release`](actions/prepare-extension-release) - Create the release branch & PR with checklist
 - [`prepare-mysql`](actions/prepare-mysql) - Enable MySQL, handle authentication compatibility

--- a/packages/github-actions/actions/merge-trunk-develop-pr/README.md
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/README.md
@@ -1,0 +1,28 @@
+# PR to merge `trunk` to `develop`
+
+This action provides the following functionality for GitHub Actions users:
+
+- Create a PR to merge `trunk` to `develop` after a release done with the `woocommerce/grow/prepare-extension-release`
+
+## Usage
+
+See [action.yml](action.yml)
+
+#### Basic:
+
+```yaml
+name: PR to merge a released trunk
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - trunk
+
+jobs:
+  automerge_trunk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v1
+```

--- a/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
@@ -4,15 +4,6 @@ description: Create a PR to merge `trunk` to `develop` after a release
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: "Set up git config"
-      shell: bash
-      # Use the github-actions bot account to commit.
-      # https://api.github.com/users/github-actions%5Bbot%5D
-      run: |
-        git config user.name github-actions[bot]
-        git config user.email 41898282+github-actions[bot]@users.noreply.github.com
     - name: "Make the PR"
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}
       uses: actions/github-script@v6

--- a/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
@@ -1,0 +1,28 @@
+name: Merge `trunk` to `develop` PR
+description: Create a PR to merge `trunk` to `develop` after a release
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: "Set up git config"
+      shell: bash
+      # Use the github-actions bot account to commit.
+      # https://api.github.com/users/github-actions%5Bbot%5D
+      run: |
+        git config user.name github-actions[bot]
+        git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+    - name: "Make the PR"
+      if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const title = '${{github.event.pull_request.title}} - Merge `trunk` to `develop`';
+          const opts = await github.rest.pulls.create( {
+            ...context.repo,
+            base: 'develop',
+            head: 'trunk',
+            title,
+            body: '${{ github.event.pull_request.html_url }}',
+          } );


### PR DESCRIPTION

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Add merge-trunk-develop-pr action to create a PR to merge `trunk` to `develop` after a release done by `woocommerce/grow/prepare-extension-release`. As automerging with `automerge-released-trunk` may not work with branch protections.


### Screenshots:

![image](https://github.com/woocommerce/grow/assets/17435/56dfeb95-fe43-43cf-8048-c6055b196879)

![image](https://github.com/woocommerce/grow/assets/17435/5cfc7184-c6de-41de-97b2-9f09dc0b023b)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a test repo that has the ``woocommerce/grow/prepare-extension-release`` set up.
2. Add to trunk another workflow following the README https://github.com/woocommerce/grow/blob/add/merge-trunk-develop-pr/packages/github-actions/actions/merge-trunk-develop-pr/README.md but with the prereleased version `actions-v1.9.1-pre`
```yml
name: PR to merge a released trunk

on:
  pull_request:
    types:
      - closed
    branches:
      - trunk

jobs:
  automerge_trunk:
    runs-on: ubuntu-latest
    steps:
      - uses: woocommerce/grow/merge-trunk-develop-pr@@actions-v1.9.1-pre
```
3. Create a develop branch
4. Create a release with ``woocommerce/grow/prepare-extension-release``. Then merge it - check that a PR to merge `trunk` to `develop` gets created. Like
   - https://github.com/tomalec/grow/pull/27
   - https://github.com/tomalec/grow/actions/runs/5742320916?pr=27
   - https://github.com/tomalec/grow/pull/43
5. Create a release with ``woocommerce/grow/prepare-extension-release``, switch a target branch to something else. Merge the PR. No PR should get created
5. Create a release with ``woocommerce/grow/prepare-extension-release``, close it without merging. No PR should get created
6. Create a PR with `release/1.2.3` as a regular user, then merge it to trunk. No PR should get created


### Additional details:
- Probably after merging this PR, we could tweak the PR checklist to mention using merging the PR created by this action, if applicable

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add merge-trunk-develop-pr action
