### PR TITLE
Restore the "merge to develop" step to the extension release checklist

### DIFF
--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -57,6 +57,7 @@ export default async ( { context, github, inputs, refName } ) => {
    When prompted for changelog entries, double-check and apply any changes if needed.
 1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.
 1. [ ] Merge this PR after the new release is successfully created and the version tags are updated.
+1. [ ] Merge \`trunk\` to \`develop\` (PR), if applicable for this repo.
 ${ postSteps }
 `;
 


### PR DESCRIPTION
_This PR reverts https://github.com/woocommerce/grow/pull/69_
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Add merge-trunk-develop-pr action to create a PR to merge `trunk` to `develop` after a release done by `woocommerce/grow/prepare-extension-release`. As automerging with `automerge-released-trunk` may not work with branch protections.


### Screenshots:




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Review the steps in 

Or more detailed: 

1. Create a test repo that has the ``woocommerce/grow/prepare-extension-release`` set up, but with the prereleased version `actions-v1.9.1-pre`
4. Trigger that workflow
5. Check the checklist, like https://github.com/tomalec/grow/pull/48


### Additional details:
- Probably after merging this PR, we could tweak the PR checklist to mention using merging the PR created by this action, if applicable

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Restore the "merge to develop" step to the extension release checklist
