### PR TITLE
Compat Checker – Fix admin notices not triggered when WooCommerce is not installed

### DIFF
--- a/packages/php/compat-checker/src/Checks/CompatCheck.php
+++ b/packages/php/compat-checker/src/Checks/CompatCheck.php
@@ -64,11 +64,6 @@ abstract class CompatCheck {
 	 * @param string $message The notice message.
 	 */
 	protected function add_admin_notice( $slug, $class, $message ) {
-		// Bail if the user is not a shop manager.
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return;
-		}
-
 		$screen = get_current_screen();
 		$hidden = array( 'update', 'update-network', 'update-core', 'update-core-network', 'upgrade', 'upgrade-network', 'network' );
 		$show   = isset( $screen->id ) && ! in_array( $screen->id, $hidden, true );

--- a/packages/php/compat-checker/src/Checks/WCCompatibility.php
+++ b/packages/php/compat-checker/src/Checks/WCCompatibility.php
@@ -303,7 +303,7 @@ class WCCompatibility extends CompatCheck {
 		$plugin_name         = $this->plugin_data['Name'];
 		$wc_version_required = ( 1 === substr_count( $this->plugin_data['RequiresWC'], '.' ) ) ? $this->plugin_data['RequiresWC'] . '.0' : $this->plugin_data['RequiresWC'] ; // Pad .0 if the min required WC version is not in semvar format.
 
-		$message    = sprintf(
+		$message = sprintf(
 			/* translators: %1$s - Plugin Name, %2$s - minimum WooCommerce version, %3$s - update WooCommerce link open, %4$s - update WooCommerce link close, %5$s - download minimum WooCommerce link open, %6$s - download minimum WooCommerce link close. */
 			esc_html__( '%1$s requires WooCommerce version %2$s or higher. Please %3$supdate WooCommerce%4$s to the latest version, or %5$sdownload the minimum required version &raquo;%6$s', 'woogrow-compat-checker' ),
 			'<strong>' . $plugin_name . '</strong>',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #82.

This PR fixes the issue wherein admin notices are not triggered when WooCommerce is not installed.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Setup the compat checker code in any of the plugins by following the Getting Started instructions here: https://github.com/woocommerce/grow/tree/trunk/packages/php/compat-checker#getting-started
2. On a fresh WordPress installation without WooCommerce installed, activate the plugin.
3. Without this PR: No admin notice is shown.
4. With this PR: Admin notices are triggered.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Admin notices not triggered when WooCommerce is not installed.
