### PR TITLE
Compat Checker – Adds perma-dismissible warning notices

### DIFF
--- a/packages/php/compat-checker/src/Checker.php
+++ b/packages/php/compat-checker/src/Checker.php
@@ -54,7 +54,8 @@ class Checker {
 		$plugin_data   = get_transient( $transient_key );
 
 		if ( false === $plugin_data ) {
-			$plugin_data = get_file_data( $plugin_file, $default_headers, 'plugin' );
+			$plugin_data         = get_file_data( $plugin_file, $default_headers, 'plugin' );
+			$plugin_data['File'] = $plugin_file;
 			set_transient( $transient_key, $plugin_data, MONTH_IN_SECONDS );
 		}
 

--- a/packages/php/compat-checker/src/Checks/CompatCheck.php
+++ b/packages/php/compat-checker/src/Checks/CompatCheck.php
@@ -121,7 +121,7 @@ abstract class CompatCheck {
 		foreach ( $this->notices as $key => $notice ) {
 			$class   = $notice['class'];
 			$message = $notice['message'];
-			echo sprintf(
+			printf(
 				'<div class="notice notice-%1$s"><p>%2$s</p></div>',
 				esc_attr( $class ),
 				wp_kses( $message, $allowed_tags )

--- a/packages/php/compat-checker/src/Checks/CompatCheck.php
+++ b/packages/php/compat-checker/src/Checks/CompatCheck.php
@@ -69,7 +69,7 @@ abstract class CompatCheck {
 		$screen = get_current_screen();
 		$hidden = array( 'update', 'update-network', 'update-core', 'update-core-network', 'upgrade', 'upgrade-network', 'network' );
 		$show   = isset( $screen->id ) && ! in_array( $screen->id, $hidden, true );
-		$slug   = plugin_basename( $this->plugin_data['File'] ) . '-' . $slug;
+		$slug   = isset( $this->plugin_data['File'] ) ? plugin_basename( $this->plugin_data['File'] ) . '-' . $slug : $slug;
 
 		/**
 		 * The Compat Check filter to show an admin notice.

--- a/packages/php/compat-checker/src/Checks/WCCompatibility.php
+++ b/packages/php/compat-checker/src/Checks/WCCompatibility.php
@@ -220,7 +220,7 @@ class WCCompatibility extends CompatCheck {
 			// Store the previous minor while we loop patch versions, which we ignore.
 			$previous_minor = $older_minor;
 
-			$supported_minor--;
+			--$supported_minor;
 		}
 
 		return $supported_wc_version;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #84 .

In this PR:

* We use `WC_Admin_Notices` to add dismissible warnings stored in the `usermeta` table.
* If `WC_Admin_Notices` is unavailable due to WooCommerce being de-activated and the notice is not a warning, we display the non-dismissible error notice.
* Fixes a couple of `phpcs` warnings.

### Screenshots:

<!--- Optional --->
![image](https://github.com/woocommerce/grow/assets/179533/8f087181-0a09-40b3-b82d-a3757a706098)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Setup Compat Checker in a WooCommerce extension by following the [Getting Started](https://github.com/woocommerce/grow/tree/trunk/packages/php/compat-checker#getting-started) section.
2. Set the `WC Tested upto` of the WooCommerce extension plugin header file to less than the current active WooCommerce version.
3. Activate the extension and notice the warning as shown in the above screenshot.
4. Click on the `Dismiss` button to dismiss the warning.
5. Visiting the page again should not display this warning.


### Additional details:

* The PR uses `add_custom_notice` method of `WC_Admin_Notices`. 
* `WC_Admin_Notices` appear only in the `plugins`, `dashboard` and `WooCommerce` pages.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Perma-dismissible warning notices.
