### PR TITLE
Use different objects of the CompatCheck class based on plugin basename

### DIFF
--- a/packages/php/compat-checker/src/Checker.php
+++ b/packages/php/compat-checker/src/Checker.php
@@ -71,14 +71,15 @@ class Checker {
 	 * @return bool
 	 */
 	public function is_compatible( $plugin_file_path, $file_version ) {
-		$checks      = array(
+		$checks          = array(
 			WPCompatibility::class,
 			WCCompatibility::class,
 		);
-		$plugin_data = $this->get_plugin_data( $plugin_file_path, $file_version );
+		$plugin_data     = $this->get_plugin_data( $plugin_file_path, $file_version );
+		$plugin_basename = plugin_basename( $plugin_file_path );
 
 		foreach ( $checks as $compatibility ) {
-			if ( ! $compatibility::instance()->is_compatible( $plugin_data ) ) {
+			if ( ! $compatibility::instance( $plugin_basename )->is_compatible( $plugin_data ) ) {
 				return false;
 			}
 		}

--- a/packages/php/compat-checker/src/Checks/CompatCheck.php
+++ b/packages/php/compat-checker/src/Checks/CompatCheck.php
@@ -47,15 +47,17 @@ abstract class CompatCheck {
 	/**
 	 * Get the instance of the CompatCheck object.
 	 *
+	 * @param string $plugin_basename The basename of the plugin.
+	 *
 	 * @return CompatCheck
 	 */
-	public static function instance() {
+	public static function instance( $plugin_basename ) {
 		$class = get_called_class();
-		if ( ! isset( self::$instances[ $class ] ) ) {
-			self::$instances[ $class ] = new $class();
+		if ( ! isset( self::$instances[ $class ][ $plugin_basename ] ) ) {
+			self::$instances[ $class ][ $plugin_basename ] = new $class();
 		}
 
-		return self::$instances[ $class ];
+		return self::$instances[ $class ][ $plugin_basename ];
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

The `CompatCheck` class creates instances based on the object. This PR uses the `plugin_basename` to create more unique objects. Adding this allows the compat checker to be used with multiple plugins.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Setup Compat Checker in two WooCommerce extension by following the [Getting Started](https://github.com/woocommerce/grow/tree/trunk/packages/php/compat-checker#getting-started) section. Let the two extensions be WooCommerce Points and Rewards and WooCommerce Coupon Campaigns.
2. Run all the tests in the Compat Checker PR from here: https://github.com/woocommerce/grow/pull/79 with both the extensions activated.
3. Before PR: Only admin notice from one plugin is displayed because the `CompatCheck` class generates only one object.
4. After PR: Notices from both the plugins are displayed.


### Screenshots

![image](https://github.com/woocommerce/grow/assets/179533/b97c1a1c-2900-4a6e-80e0-2e207e167674)


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Different instances of CompatCheck based on plugin basename.
