### PR TITLE
Update woo.com domain, update feature-requests URL in yeoman generator

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,7 +13,3 @@ Grow Packages is licensed under the GPLv3+, and all contributions to the project
 ## Reporting Security Issues
 
 Please see [SECURITY.md](./SECURITY.md).
-
-## Feature Requests
-
-Feature requests can be submitted to our [ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ The packages here are too experimental or too Grow-specific to be shared Woo-wid
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
-	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
+	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -161,6 +161,6 @@ gitGraph
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
-	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
+	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/packages/js/generator-grow/README.md
+++ b/packages/js/generator-grow/README.md
@@ -24,6 +24,6 @@ Or call task separately:
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
-	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
+	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/packages/js/generator-grow/generators/github/github.test.js
+++ b/packages/js/generator-grow/generators/github/github.test.js
@@ -22,7 +22,7 @@ describe( ':github', function () {
 	} );
 	it( 'generate `.github/workflows/branch-labels.yml` file', async function () {
 		await helpers.run( githubPath ).then( function () {
-			assert.file( '.github/worflows/branch-labels.yml' );
+			assert.file( '.github/workflows/branch-labels.yml' );
 		} );
 	} );
 	it( 'Should use given project title in CONTRIBUTING.md', async function () {
@@ -62,25 +62,28 @@ describe( ':github', function () {
 			);
 		} );
 	} );
-	it( 'When ideasboard id is given, should generate ideas board link to the category.', async function () {
+	it( 'When slug is given, should generate feature requests page link.', async function () {
 		await helpers
 			.run( githubPath )
-			.withPrompts( { ideasboard: 1234567 } )
+			.withPrompts( { slug: 'foo-bar' } )
 			.then( function () {
 				assert.fileContent(
 					'.github/CONTRIBUTING.md',
-					'https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=1234567'
+					'https://woo.com/feature-requests/foo-bar'
 				);
 			} );
 	} );
-	it( 'If no ideasboard id given, should generate ideas board link with no category specified.', async function () {
+	it( 'If no slug is given, should use app name to generate the link.', async function () {
 		await helpers
 			.run( githubPath )
-			.withPrompts( { ideasboard: '' } )
-			.then( function () {
+			.withPrompts( { slug: '' } )
+			.then( function ( runResult ) {
+				// Appname default to the folder name.
+				const appname = runResult.generator.appname;
+
 				assert.fileContent(
 					'.github/CONTRIBUTING.md',
-					/https\:\/\/ideas\.woocommerce\.com\/forums\/133476-woocommerce[^?]/
+					`https://woo.com/feature-requests/${ appname }`
 				);
 			} );
 	} );

--- a/packages/js/generator-grow/generators/github/index.js
+++ b/packages/js/generator-grow/generators/github/index.js
@@ -14,10 +14,9 @@ export default class GitHubGenerator extends Generator {
 			},
 			{
 				type: 'input',
-				name: 'ideasboard',
-				message:
-					"What's the plugin ideas board's category number? (leave empty if none)",
-				default: '',
+				name: 'slug',
+				message: "What's the plugin slug for feature requests page?",
+				default: this.appname.replace( /\s+/g, '-' ).toLowerCase(),
 			},
 		] );
 	}

--- a/packages/js/generator-grow/generators/github/templates/CODE_OF_CONDUCT.md
+++ b/packages/js/generator-grow/generators/github/templates/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/packages/js/generator-grow/generators/github/templates/CONTRIBUTING.md
+++ b/packages/js/generator-grow/generators/github/templates/CONTRIBUTING.md
@@ -16,4 +16,4 @@ Please see [SECURITY.md](./SECURITY.md).
 
 ## Feature Requests
 
-Feature requests can be submitted to our [ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce<%= ideasboard ? `?category_id=${ ideasboard }` : '' %>). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+Feature requests can be submitted to our [feature requests page](https://woo.com/feature-requests/<%= slug %>/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.

--- a/packages/js/storybook/README.md
+++ b/packages/js/storybook/README.md
@@ -18,6 +18,6 @@ Example of working implementation can be found in [GLA plugin storybook folder](
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
-	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
+	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/packages/php/compat-checker/src/Checks/WCCompatibility.php
+++ b/packages/php/compat-checker/src/Checks/WCCompatibility.php
@@ -28,7 +28,7 @@ class WCCompatibility extends CompatCheck {
 	 *
 	 * @var int|float The miniumum supported WooCommerce versions before the latest.
 	 *
-	 * @see https://woocommerce.com/support-policy/
+	 * @see https://woo.com/support-policy/
 	 */
 	private $min_wc_semver = 0.2; // By default, the latest minus two version.
 


### PR DESCRIPTION
This is a leftover for peeuvX-13n-p2

### Changes proposed in this Pull Request:
- Update woo.com domain
- update feature-requests URL in yeoman generator
- fix a typo in tests for workflows


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Search the codebase for `woocommerce.com` - no source files should match
2. test yeoman
   1. Unit tests `cd packages/js/generator-grow/ && npm run test`
   2. Smoke
      1. Install the generator according to [its readme ](https://github.com/woocommerce/grow/tree/trunk/packages/js/generator-grow#readme)
      2. create a test directory
      3. run `yo grow` there
      4. Search for `woocommerce.com`. Check that feature requests link in `.github/CONTRIBUTING.md` works


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Update woo.com domain name.