### PR TITLE
Add update docs & ideas step to extension release checklist

### DIFF
--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -58,6 +58,10 @@ export default async ( { context, github, inputs, refName } ) => {
 1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.
 1. [ ] Merge this PR after the new release is successfully created and the version tags are updated.
 1. [ ] Merge \`trunk\` to \`develop\` (PR), if applicable for this repo.
+1. [ ] Update documentation
+   - [ ] Publish any new required docs
+   - [ ] Update triggers/rules/actions listing pages
+1. [ ] Mark related ideas complete [on the feature requests page](https://woo.com/feature-requests/${ extensionPackageName }/).
 ${ postSteps }
 `;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add update docs & ideas step to extension release checklist

Currently, we have that step for 
- AutomateWoo
- AW - Birthdays
- AW - Referrals
- Facebook for Woocommerce

I think we can unify it and have it for all, with a link to the page. So we would have a tiny help and motivation to review and maintain our community ideas boards.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Review the checklist template


### Additional details:

1. After it's merged we can remove those steps from individual repos.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Add update docs & ideas step to extension release checklist