### PR TITLE
Add a new workflow to GitHub Actions for deleting the test build of Custom GitHub actions

### DIFF
--- a/.github/workflows/github-actions-delete-test-build.yml
+++ b/.github/workflows/github-actions-delete-test-build.yml
@@ -1,0 +1,33 @@
+name: GitHub Actions - Delete Test Build
+
+on:
+  delete:
+
+jobs:
+  DeleteTestBuild:
+    name: Delete Test Build
+    runs-on: ubuntu-latest
+    if: github.event.ref_type == 'branch'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: trunk
+
+      - name: Delete test build branch
+        run: |
+          BRANCH_NAME="${{ github.event.ref }}-test-build"
+          REMOTE_BRANCH_NAME="origin/${BRANCH_NAME}"
+
+          git fetch --prune --no-tags --depth=1 origin
+
+          # Check if the test build branch exists.
+          if [ -n "$(git branch --list --remote "$REMOTE_BRANCH_NAME")" ]; then
+            AUTHOR_INFO=$(git show --no-patch --pretty=format:"%an %ae" "${REMOTE_BRANCH_NAME}")
+
+            # Check if the author of the last commit is the github-actions bot account.
+            # https://api.github.com/users/github-actions%5Bbot%5D
+            if [[ "$AUTHOR_INFO" == 'github-actions[bot] 41898282+github-actions[bot]@users.noreply.github.com' ]]; then
+              git push -d origin "$BRANCH_NAME"
+            fi
+          fi

--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -76,8 +76,9 @@ Create a test build on the given branch and commit it to a separate branch with 
 1. Manually run the workflow with the target branch.
 1. Wait for the triggered workflow run to complete.
 1. View the summary of the workflow run to use the test build.
-1. Take the branch name `add/my-action` and action path `greet-visitor` as an example. After a test build is created, it should be able to test the custom action by `woocommerce/grow/greet-visitor@add/my-action-test-build`
-1. Delete the test branch once it is no longer needed.
+1. Take the branch name `add/my-action` and action path `greet-visitor` as an example:
+   - After a test build is created, it should be able to test the custom action by `woocommerce/grow/greet-visitor@add/my-action-test-build`.
+   - After the `add/my-action` branch is deleted, the Workflow [GitHub Actions - Delete Test Build](https://github.com/woocommerce/grow/actions/workflows/github-actions-delete-test-build.yml) will delete the `my-action-test-build` branch.
 
 ### Directory structure of release build
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After adding the test build of Custom GitHub actions by #92, it occurred to me that it might be possible to automate it some more. Therefore, this PR adds a new workflow to GitHub Actions of this repo for deleting the test build of Custom GitHub actions.

### Screenshots:

https://github.com/woocommerce/grow/assets/17420811/1663afc5-10c6-4e5a-b5cd-beb1368ff3bb

### Detailed test instructions:

💡 Since it's unable to actually test this PR before merging it into `trunk`, I verified its results in my forked repo and the https://github.com/eason9487/grow/commit/7c2c739e23ee45e941ce7f2eab386683b68a87b9 commit.

1. View the workflow run to observe the deletion of a test build created from `demo-auto-deletion`: https://github.com/eason9487/grow/actions/runs/7045267800
1. Read the [Create a test build](https://github.com/woocommerce/grow/tree/525805b90e109db0a693f609670e9f2e9cdcf649/packages/github-actions#create-a-test-build) section in README to determine if it's clear and easy to understand.
