### PR TITLE
Fix "using ${var} in strings is deprecated" notice

### DIFF
--- a/packages/php/woorelease-extension/src/Utils/VersionReplace.php
+++ b/packages/php/woorelease-extension/src/Utils/VersionReplace.php
@@ -53,7 +53,7 @@ class VersionReplace {
 				$cleanup = sprintf( 'find ./%1$s -name "*.php.bak" -type f -delete', $path );
 			} else {
 				$command = $sed_command . $local_path;
-				$cleanup = "unlink ${local_path}.bak";
+				$cleanup = sprintf('unlink %s.bak', $local_path);
 			}
 			Utils::exec_sprintf( $command );
 			Utils::exec_sprintf( $cleanup );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Replace `${var}` deprecated usage with sprintf

Closes #99.


### Detailed test instructions:

1. Try running `./bin/wr simulate` for any repo and confirm no errors is shown.


