### PR TITLE
Get Plugin Releases - Prevent unstable releases

### DIFF
--- a/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
+++ b/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
@@ -60,7 +60,7 @@ function parsePluginVersions( releases = {} ) {
 					version !== 'trunk' &&
 					version !== 'other' &&
 					! version.includes( 'beta' ) &&
-					( includeRC || semverCompare( latest, version ) <= 0 )
+					( isRC( version ) || semverCompare( latest, version ) <= 0 )
 			)
 			.sort( semverCompare );
 

--- a/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
+++ b/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
@@ -53,12 +53,14 @@ function parsePluginVersions( releases = {} ) {
 	const output = [];
 
 	if ( slug !== 'wordpress' ) {
+		const latest = releases.version;
 		const versions = Object.keys( releases.versions )
 			.filter(
 				( version ) =>
 					version !== 'trunk' &&
 					version !== 'other' &&
-					! version.includes( 'beta' )
+					! version.includes( 'beta' ) &&
+					semverCompare( latest, version ) <= 0
 			)
 			.sort( semverCompare );
 

--- a/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
+++ b/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
@@ -60,7 +60,7 @@ function parsePluginVersions( releases = {} ) {
 					version !== 'trunk' &&
 					version !== 'other' &&
 					! version.includes( 'beta' ) &&
-					( includeRC || semverCompare( latest, version ) <= 0)
+					( includeRC || semverCompare( latest, version ) <= 0 )
 			)
 			.sort( semverCompare );
 

--- a/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
+++ b/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
@@ -60,7 +60,7 @@ function parsePluginVersions( releases = {} ) {
 					version !== 'trunk' &&
 					version !== 'other' &&
 					! version.includes( 'beta' ) &&
-					semverCompare( latest, version ) <= 0
+					( includeRC || semverCompare( latest, version ) <= 0)
 			)
 			.sort( semverCompare );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #101 

This PR checks the release versions and ensures the maximum release version is the latest stable one (defined in "version" param under [the JSON API](https://api.wordpress.org/plugins/info/1.0/woocommerce.json) .

### Screenshots:

Local:
- The first command is before the PR
- Second after the PR

<img width="676" alt="Screenshot 2024-04-11 at 21 21 51" src="https://github.com/woocommerce/grow/assets/5908855/e67a0f26-6105-4ec5-95cc-6c8f381c2758">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Verify https://github.com/woocommerce/google-listings-and-ads/actions/runs/8652279994/job/23724824443?pr=2365 is fetching the right versions

1. Clone this repo locally
2. Compile the code using `npm run build` (notice you might need to remove some GH output/input code) 
3. Run node node get-plugin-releases.js
4. See it returns 8.8.0 as the latest
5. Checkout this PR
6. Repeat step 3
7. See it returns 8.7.0 as the latest


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Prevent unstable releases to be returned
