### PR TITLE
Adjust the publishing workflow of `compat-checker` to run only when the changed files are related to it

### DIFF
--- a/.github/workflows/github-action-publish-compat-checker.yml
+++ b/.github/workflows/github-action-publish-compat-checker.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - trunk
+    paths:
+      - "**.js"
+      - "**.scss"
+      - "packages/php/compat-checker/**"
+      - .github/workflows/github-action-publish-compat-checker.yml
 
 jobs:
   deploy:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, [the Publish Compat Checker package workflow](https://github.com/woocommerce/grow/actions/workflows/github-action-publish-compat-checker.yml) also runs when unrelated changes are pushed to `trunk`.

This PR adjusts the workflow to run only for the related changes.
Docs reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

### Detailed test instructions:

N/A as it can only be tested after merging and having subsequent changes onto `trunk`
