### PR TITLE
Remove the unrelated trigger paths from the publishing workflow of `compat-checker`

### DIFF
--- a/.github/workflows/github-action-publish-compat-checker.yml
+++ b/.github/workflows/github-action-publish-compat-checker.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - trunk
     paths:
-      - "**.js"
-      - "**.scss"
       - "packages/php/compat-checker/**"
       - .github/workflows/github-action-publish-compat-checker.yml
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove the unrelated trigger paths from the publishing workflow of `compat-checker`.

Docs reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

💡 I will be skipping the code review process as it can be optional for a devs-facing only change.

### Detailed test instructions:

N/A as it can only be tested after merging and having subsequent changes onto `trunk`
