### PR TITLE
Upgrade the `automerge-released-trunk`, `coverage-report`, and `prepare-php` actions to use Node.js v20

### DIFF
--- a/packages/github-actions/actions/automerge-released-trunk/README.md
+++ b/packages/github-actions/actions/automerge-released-trunk/README.md
@@ -24,5 +24,5 @@ jobs:
   automerge_trunk:
     runs-on: ubuntu-latest
     steps:
-      - uses: woocommerce/grow/automerge-released-trunk@actions-v1
+      - uses: woocommerce/grow/automerge-released-trunk@actions-v2
 ```

--- a/packages/github-actions/actions/automerge-released-trunk/action.yml
+++ b/packages/github-actions/actions/automerge-released-trunk/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: "Merge the release to develop"
       shell: bash
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}

--- a/packages/github-actions/actions/coverage-report/README.md
+++ b/packages/github-actions/actions/coverage-report/README.md
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
 
       - name: Run unit tests (with coverage report)
         run: phpdbg -qrr vendor/bin/phpunit --coverage-clover=tests/coverage/report.xml
 
       - name: PHP unit coverage report
-        uses: woocommerce/grow/coverage-report@actions-v1
+        uses: woocommerce/grow/coverage-report@actions-v2
         with:
           base-branch: trunk
           test-comment: "PHP unit test coverage"

--- a/packages/github-actions/actions/coverage-report/action.yml
+++ b/packages/github-actions/actions/coverage-report/action.yml
@@ -42,7 +42,7 @@ runs:
 
     # Download coverage report artifact
     - if: github.event_name == 'pull_request'
-      uses: dawidd6/action-download-artifact@v2.14.1
+      uses: dawidd6/action-download-artifact@v3
       continue-on-error: true
       with:
         workflow: ${{ inputs.workflow }}
@@ -52,7 +52,7 @@ runs:
 
     # Save coverage report as an artifact
     - if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.report-name }}
         path: "${{ inputs.report-path }}/${{ inputs.report-file }}"

--- a/packages/github-actions/actions/prepare-php/README.md
+++ b/packages/github-actions/actions/prepare-php/README.md
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
 
       - name: Run unit tests
         run: vendor/bin/phpunit
@@ -37,10 +37,10 @@ jobs:
 ```yaml
 steps:
   - name: Checkout repository
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - name: Prepare PHP
-    uses: woocommerce/grow/prepare-php@actions-v1
+    uses: woocommerce/grow/prepare-php@actions-v2
     with:
       php-version: 8.1
 ```
@@ -50,10 +50,10 @@ steps:
 ```yaml
 steps:
   - name: Checkout repository
-    uses: actions/checkout@v3
+    uses: actions/checkout@v4
 
   - name: Prepare PHP
-    uses: woocommerce/grow/prepare-php@actions-v1
+    uses: woocommerce/grow/prepare-php@actions-v2
     with:
       tools: cs2pr
 
@@ -70,10 +70,10 @@ To use Composer v1, set this parameter with `composer:v1`
 ```yaml
 steps:
   - name: Checkout repository
-    uses: actions/checkout@v3
+    uses: actions/checkout@v4
 
   - name: Prepare PHP
-    uses: woocommerce/grow/prepare-php@actions-v1
+    uses: woocommerce/grow/prepare-php@actions-v2
     with:
       coverage: xdebug
 ```
@@ -87,10 +87,10 @@ The `coverage` is `"none"` by default to disable both `Xdebug` and `PCOV`.
 ```yaml
 steps:
   - name: Checkout repository
-    uses: actions/checkout@v3
+    uses: actions/checkout@v4
 
   - name: Prepare PHP
-    uses: woocommerce/grow/prepare-php@actions-v1
+    uses: woocommerce/grow/prepare-php@actions-v2
     with:
       install-deps: "no"
 

--- a/packages/github-actions/actions/prepare-php/action.yml
+++ b/packages/github-actions/actions/prepare-php/action.yml
@@ -50,7 +50,7 @@ runs:
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     # Set up Composer caching.
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache-config.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR upgrades 3 actions that mainly use external actions:

- `automerge-released-trunk`
- `coverage-report`
- `prepare-php`

### Detailed test instructions:

💡 I don't prepare a test for the `automerge-released-trunk` action as it has only an update for `actions/checkout` and it should work well.

1. View a previous workflow run used v1 `coverage-report` and `prepare-php`
   - https://github.com/woocommerce/automatewoo/actions/runs/8756576318
   - There are warnings of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/8fb120f7-bb8c-4ae6-9afe-e3e2000c6526)
2. View a test workflow run used updated `coverage-report` and `prepare-php`
   - https://github.com/woocommerce/automatewoo/actions/runs/8799042429?pr=1740
   - There's no more warning related to the actions in this PR
      ![image](https://github.com/woocommerce/grow/assets/17420811/379bb65e-e90d-484c-9c08-aebd8456702a)
3. View the test PR
   - woocommerce/automatewoo/pull/1740
   - The **Coverage report** was commented correclty. 
      ![image](https://github.com/woocommerce/grow/assets/17420811/49940451-a94a-4f65-b887-c48a2e1d45f5)
