### PR TITLE
Update the version in docs of the `hook-documentation`, `prepare-mysql`, and `run-qit-annotate` actions to v2

### DIFF
--- a/packages/github-actions/actions/hook-documentation/readme.md
+++ b/packages/github-actions/actions/hook-documentation/readme.md
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Checks out a branch instead of a commit in detached HEAD state
           ref: ${{ github.head_ref }}
@@ -50,7 +50,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: woocommerce/grow/hook-documentation@actions-v1
+        uses: woocommerce/grow/hook-documentation@actions-v2
         with:
           debug-output: yes
           source-directories: src/,templates/

--- a/packages/github-actions/actions/prepare-mysql/README.md
+++ b/packages/github-actions/actions/prepare-mysql/README.md
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v1
+        uses: woocommerce/grow/prepare-mysql@actions-v2
 
       - name: Create database
         run: mysql -e 'CREATE DATABASE IF NOT EXISTS wordpress_test;' -u root -proot

--- a/packages/github-actions/actions/run-qit-annotate/README.md
+++ b/packages/github-actions/actions/run-qit-annotate/README.md
@@ -37,7 +37,7 @@ jobs:
 
       - name: Security test
         id: security-test
-        uses: woocommerce/grow/run-qit-annotate@actions-v1
+        uses: woocommerce/grow/run-qit-annotate@actions-v2
         timeout-minutes: 5
         with:
           type: security


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR updates docs for 3 actions that don't use Node.js or other actions:

- `hook-documentation`
- `prepare-mysql`
- `run-qit-annotate`

These actions won't have a difference with v1 but it would be nicer to update their major version to v2 together. 

### Detailed test instructions:

Check if there are any relevant content is missing from the update.
