### PR TITLE
Upgrade the `phpcs-diff` action to use Node.js v20

### DIFF
--- a/packages/github-actions/actions/phpcs-diff/README.md
+++ b/packages/github-actions/actions/phpcs-diff/README.md
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run PHPCS to changed lines of code
-        uses: woocommerce/grow/phpcs-diff@actions-v1
+        uses: woocommerce/grow/phpcs-diff@actions-v2
 ```
 
 #### Specify the PHP version:
@@ -41,7 +41,7 @@ jobs:
 ```yaml
 steps:
   - name: Run PHPCS to changed lines of code
-    uses: woocommerce/grow/phpcs-diff@actions-v1
+    uses: woocommerce/grow/phpcs-diff@actions-v2
     with:
       php-version: 8.1
 ```

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -16,9 +16,7 @@ runs:
         fetch-depth: 2
 
     # Set up PHP.
-    # - uses: woocommerce/grow/prepare-php@actions-v2
-    # Temporarily using test build
-    - uses: woocommerce/grow/prepare-php@update/108-nodejs-v20-github-actions-external-only-test-build
+    - uses: woocommerce/grow/prepare-php@actions-v2
       with:
         php-version: ${{ inputs.php-version }}
 

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -11,12 +11,12 @@ runs:
   using: composite
   steps:
     # Checkout repository.
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     # Set up PHP.
-    - uses: woocommerce/grow/prepare-php@actions-v1
+    - uses: woocommerce/grow/prepare-php@actions-v2
       with:
         php-version: ${{ inputs.php-version }}
 

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -16,7 +16,9 @@ runs:
         fetch-depth: 2
 
     # Set up PHP.
-    - uses: woocommerce/grow/prepare-php@actions-v2
+    # - uses: woocommerce/grow/prepare-php@actions-v2
+    # Temporarily using test build
+    - uses: woocommerce/grow/prepare-php@update/108-nodejs-v20-github-actions-external-only-test-build
       with:
         php-version: ${{ inputs.php-version }}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR upgrades the `phpcs-diff` action to use Node.js v20

#### 📌 Checklist before merging (@eason9487)

- [x] Revert 3bba1ed4aade5406450b8ce11f397fd1348d127f before merging this PR

### Detailed test instructions:

1. View a previous workflow run used v1 `phpcs-diff` action
   - https://github.com/woocommerce/automatewoo-birthdays/actions/runs/8699492678
   - There are warnings of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/47d75398-4c73-4db7-8f2c-6a4c1d04ceb7)
2. View a test workflow run used updated `phpcs-diff` action
   - https://github.com/woocommerce/automatewoo-birthdays/actions/runs/8812893621?pr=134
   - This run failed on purpose to test if it can report PHP linting errors for the diff lines
   - There's no more warning of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/d3f86300-73b5-4bd5-ab46-7640145cbe72)
3. View the test PR
   - woocommerce/automatewoo-birthdays/pull/134
   - The annotations are shown
      ![image](https://github.com/woocommerce/grow/assets/17420811/7b01a84b-cce6-4017-bfdc-bc3ccead0261)
      ![image](https://github.com/woocommerce/grow/assets/17420811/00c844a7-c25a-4b90-885f-319258a9989b)
