### PR TITLE
Upgrade the `eslint-annotation` and `stylelint-annotation` actions to use Node.js v20

### DIFF
--- a/packages/github-actions/actions/eslint-annotation/README.md
+++ b/packages/github-actions/actions/eslint-annotation/README.md
@@ -24,12 +24,12 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
-      - uses: woocommerce/grow/eslint-annotation@actions-v1
+      - uses: woocommerce/grow/eslint-annotation@actions-v2
         with:
           formatter-dest: "./my-formatter.cjs"
       - run: eslint --format ./my-formatter.cjs src

--- a/packages/github-actions/actions/stylelint-annotation/README.md
+++ b/packages/github-actions/actions/stylelint-annotation/README.md
@@ -24,12 +24,12 @@ jobs:
   stylelint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
-      - uses: woocommerce/grow/stylelint-annotation@actions-v1
+      - uses: woocommerce/grow/stylelint-annotation@actions-v2
         with:
           formatter-dest: "./my-formatter.cjs"
       - run: stylelint --custom-formatter ./my-formatter.cjs "**/*.css"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR upgrades the `eslint-annotation` and `stylelint-annotation` actions to use Node.js v20

### Detailed test instructions:

1. View a previous workflow run used v1 `eslint-annotation` and `stylelint-annotation` actions
   - https://github.com/woocommerce/automatewoo-birthdays/actions/runs/8699515674
   - There are warnings of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/2e522efd-c578-49d8-b086-d828c011ebaf)
2. View a test workflow run used updated `eslint-annotation` and `stylelint-annotation` actions
   - https://github.com/woocommerce/automatewoo-birthdays/actions/runs/8815885945?pr=134
   - This run failed on purpose to test if it can report JS and CSS linting errors
   - There's no more warning of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/c15383e6-36c8-422a-9c8c-038ce5708162)
3. View the test PR
   - woocommerce/automatewoo-birthdays/pull/134
   - The annotations are shown
      ![image](https://github.com/woocommerce/grow/assets/17420811/2a79b3b6-a7cc-4aaa-a0e6-22b503e71322)
      ![image](https://github.com/woocommerce/grow/assets/17420811/541ae40a-278c-4681-819a-4bc9d0b05d13)
      ![image](https://github.com/woocommerce/grow/assets/17420811/806cff3c-2358-48f9-903e-d9cf3ed79041)
