### PR TITLE
Upgrade the `get-plugin-releases` action to use Node.js v20

### DIFF
--- a/packages/github-actions/actions/get-plugin-releases/README.md
+++ b/packages/github-actions/actions/get-plugin-releases/README.md
@@ -23,25 +23,25 @@ jobs:
     steps:
       - name: Get Release versions from WooCommerce
         id: wc-versions
-        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: woocommerce
 
       - name: Get Release versions from WordPress
         id: wp-versions
-        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: wordpress
 
       - name: Get Release versions from GLA
         id: gla-versions
-        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: google-listings-and-ads
 
       - name: Get L-3 Release versions from WC including RC
         id: wc-versions-l3-rc
-        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: woocommerce
           releases: 4
@@ -49,7 +49,7 @@ jobs:
 
       - name: Get L-2 Release versions from WC including patches
         id: wc-versions-patches
-        uses: woocommerce/grow/get-plugin-releases@actions-v1
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: woocommerce
           includePatches: true

--- a/packages/github-actions/actions/get-plugin-releases/action.yml
+++ b/packages/github-actions/actions/get-plugin-releases/action.yml
@@ -20,5 +20,5 @@ outputs:
     description: The versions array in the format ["7.4","7.5","7.6"]
 
 runs:
-  using: node16
+  using: node20
   main: get-plugin-releases.mjs

--- a/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
+++ b/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
@@ -6,15 +6,14 @@ import core from '@actions/core';
 /**
  * Internal dependencies
  */
-import handleActionErrors from '../../../utils/handle-action-errors';
+import handleActionErrors from '../../../utils/handle-action-errors.js';
 
-async function getPluginReleases() {
-	const slug = getInput( 'slug' );
-	const apiEndpoint = getAPIEndpoint( slug );
+async function getPluginReleases( inputs ) {
+	const apiEndpoint = getAPIEndpoint( inputs.slug );
 
 	return fetch( apiEndpoint )
 		.then( ( res ) => res.json() )
-		.then( parsePluginVersions );
+		.then( ( data ) => parsePluginVersions( data, inputs ) );
 }
 
 function getAPIEndpoint( slug ) {
@@ -43,12 +42,8 @@ function setOutput( key, value ) {
 	core.setOutput( key, value );
 }
 
-function parsePluginVersions( releases = {} ) {
-	const slug = getInput( 'slug' );
-	const numberOfReleases = parseInt( getInput( 'releases' ), 10 );
-	const includeRC = getInput( 'includeRC' );
-	const includePatches = getInput( 'includePatches' );
-
+function parsePluginVersions( releases = {}, inputs ) {
+	const { slug, numberOfReleases, includeRC, includePatches } = inputs;
 	const output = [];
 
 	if ( slug !== 'wordpress' ) {
@@ -135,6 +130,16 @@ function semverCompare( a, b ) {
 	);
 }
 
-getPluginReleases()
-	.then( () => core.info( 'Finish getting the release versions.' ) )
-	.catch( handleActionErrors );
+// Directly perform this action if it's running in GitHub Actions.
+if ( process.env.GITHUB_ACTIONS ) {
+	const inputs = {
+		slug: getInput( 'slug' ),
+		numberOfReleases: parseInt( getInput( 'releases' ), 10 ),
+		includeRC: getInput( 'includeRC' ),
+		includePatches: getInput( 'includePatches' ),
+	};
+
+	getPluginReleases( inputs )
+		.then( () => core.info( 'Finish getting the release versions.' ) )
+		.catch( handleActionErrors );
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR upgrades the `get-plugin-releases` action to use Node.js v20.
In addition, it makes the action easier to develop and test.

### Detailed test instructions:

1. Test the action locally
   1. Use Node.js v20
   2. `cd packages/github-actions`
   3. `npm install`
   4. `node --watch actions/get-plugin-releases/src/get-plugin-releases.js`
   5. There should be no output because it's changed to only perform directly when running in GitHub Actions
   6. Edit the `packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js` file and save it with the following test code at the end of the file
      ```js
      getPluginReleases( {
      	slug: 'wordpress',
      	numberOfReleases: 10,
      	includeRC: false,
      	includePatches: false,
      } );
      
      getPluginReleases( {
      	slug: 'woocommerce',
      	numberOfReleases: 10,
      	includeRC: true,
      	includePatches: true,
      } );
      ```
   7. There should be corresponding outputs
      ![image](https://github.com/woocommerce/grow/assets/17420811/45924b80-08f5-486a-89b7-f32d235917ef)
2. View a previous workflow run used v1 action
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/8652279994
   - There are warnings of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/32f1a9d9-5d65-48cd-8a54-5be271f253c9)
3. View a test workflow run used updated action
   - https://github.com/eason9487/grow/actions/runs/8828174294
   - There's no more warning of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/c00a8f6e-d2e7-4394-bbc2-ca65c16146ae)
4. View the versions output
   - https://github.com/eason9487/grow/actions/runs/8828174294/job/24236656175#step:8:1
      ![image](https://github.com/woocommerce/grow/assets/17420811/dd85557a-d217-48c0-8c7b-98aa78ab8234)
