### PR TITLE
Upgrade the `run-qit-extension` action to use Node.js v20

### DIFF
--- a/.github/workflows/run-qit-all.yml
+++ b/.github/workflows/run-qit-all.yml
@@ -55,7 +55,10 @@ on:
       options:
         description: 'Additional options for `qit` command, like `--optional_features=hpos`.'
         required: false
-
+  # Temporarily testing the current PR branch
+  push:
+    branches:
+      - update/108-nodejs-v20-github-actions-run-qit-extension
 
 jobs:
     qit-tests:
@@ -66,20 +69,27 @@ jobs:
           fail-fast: false
           matrix:
             # List of extensions to be tested.
-            extension: [automatewoo, automatewoo-birthdays, automatewoo-referrals, google-listings-and-ads, woocommerce-google-analytics-integration]
+            # extension: [automatewoo, automatewoo-birthdays, automatewoo-referrals, google-listings-and-ads, woocommerce-google-analytics-integration]
+            # Temporarily skipping private repos
+            extension: [google-listings-and-ads, woocommerce-google-analytics-integration]
         steps:
           - name: Run QIT
-            uses: woocommerce/grow/run-qit-extension@actions-v1
+            # uses: woocommerce/grow/run-qit-extension@actions-v1
+            # Temporarily using the action of the current PR branch
+            uses: woocommerce/grow/packages/github-actions/actions/run-qit-extension@update/108-nodejs-v20-github-actions-run-qit-extension
             with:
               qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
               qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}
-              version: ${{ inputs.version }}
-              wait: ${{ inputs.wait }}
-              test-activation: ${{ inputs.test-activation }}
-              test-security: ${{ inputs.test-security }}
-              test-phpstan: ${{ inputs.test-phpstan }}
-              test-api: ${{ inputs.test-api }}
-              test-e2e: ${{ inputs.test-e2e }}
+              # version: ${{ inputs.version }}
+              # wait: ${{ inputs.wait }}
+              # test-activation: ${{ inputs.test-activation }}
+              # test-security: ${{ inputs.test-security }}
+              # test-phpstan: ${{ inputs.test-phpstan }}
+              # test-api: ${{ inputs.test-api }}
+              # test-e2e: ${{ inputs.test-e2e }}
               extension: ${{ matrix.extension }}
-              ignore-fail: ${{ inputs.ignore-fail }}
-              options: ${{ inputs.options }}
+              # ignore-fail: ${{ inputs.ignore-fail }}
+              # options: ${{ inputs.options }}
+              # Temporarily commenting out inputs
+              version: dev
+              test-e2e: false

--- a/.github/workflows/run-qit-all.yml
+++ b/.github/workflows/run-qit-all.yml
@@ -55,10 +55,7 @@ on:
       options:
         description: 'Additional options for `qit` command, like `--optional_features=hpos`.'
         required: false
-  # Temporarily testing the current PR branch
-  push:
-    branches:
-      - update/108-nodejs-v20-github-actions-run-qit-extension
+
 
 jobs:
     qit-tests:
@@ -69,27 +66,20 @@ jobs:
           fail-fast: false
           matrix:
             # List of extensions to be tested.
-            # extension: [automatewoo, automatewoo-birthdays, automatewoo-referrals, google-listings-and-ads, woocommerce-google-analytics-integration]
-            # Temporarily skipping private repos
-            extension: [google-listings-and-ads, woocommerce-google-analytics-integration]
+            extension: [automatewoo, automatewoo-birthdays, automatewoo-referrals, google-listings-and-ads, woocommerce-google-analytics-integration]
         steps:
           - name: Run QIT
-            # uses: woocommerce/grow/run-qit-extension@actions-v1
-            # Temporarily using the action of the current PR branch
-            uses: woocommerce/grow/packages/github-actions/actions/run-qit-extension@update/108-nodejs-v20-github-actions-run-qit-extension
+            uses: woocommerce/grow/run-qit-extension@actions-v1
             with:
               qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
               qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}
-              # version: ${{ inputs.version }}
-              # wait: ${{ inputs.wait }}
-              # test-activation: ${{ inputs.test-activation }}
-              # test-security: ${{ inputs.test-security }}
-              # test-phpstan: ${{ inputs.test-phpstan }}
-              # test-api: ${{ inputs.test-api }}
-              # test-e2e: ${{ inputs.test-e2e }}
+              version: ${{ inputs.version }}
+              wait: ${{ inputs.wait }}
+              test-activation: ${{ inputs.test-activation }}
+              test-security: ${{ inputs.test-security }}
+              test-phpstan: ${{ inputs.test-phpstan }}
+              test-api: ${{ inputs.test-api }}
+              test-e2e: ${{ inputs.test-e2e }}
               extension: ${{ matrix.extension }}
-              # ignore-fail: ${{ inputs.ignore-fail }}
-              # options: ${{ inputs.options }}
-              # Temporarily commenting out inputs
-              version: dev
-              test-e2e: false
+              ignore-fail: ${{ inputs.ignore-fail }}
+              options: ${{ inputs.options }}

--- a/packages/github-actions/actions/run-qit-extension/README.md
+++ b/packages/github-actions/actions/run-qit-extension/README.md
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:    
       - name: Delegate QIT Tests
-        uses: woocommerce/grow/run-qit-extension@actions-v1
+        uses: woocommerce/grow/run-qit-extension@actions-v2
         with:
           qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
           qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}

--- a/packages/github-actions/actions/run-qit-extension/action.yml
+++ b/packages/github-actions/actions/run-qit-extension/action.yml
@@ -93,7 +93,9 @@ runs:
     - name: Activation test
       id: activation
       if: ${{ inputs.test-activation == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # Temporarily using test build
+      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
       with:
         type: activation
         extension: ${{ inputs.extension }}
@@ -105,7 +107,9 @@ runs:
     - name: Security test
       id: security
       if: ${{ inputs.test-security == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # Temporarily using test build
+      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
       with:
         type: security
         extension: ${{ inputs.extension }}
@@ -117,7 +121,9 @@ runs:
     - name: PHPStan test
       id: phpstan
       if: ${{ inputs.test-phpstan == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # Temporarily using test build
+      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
       with:
         type: phpstan
         extension: ${{ inputs.extension }}
@@ -129,7 +135,9 @@ runs:
     - name: API test
       id: api
       if: ${{ inputs.test-api == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # Temporarily using test build
+      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
       with:
         type: api
         extension: ${{ inputs.extension }}
@@ -141,7 +149,9 @@ runs:
     - name: E2E test
       id: e2e
       if: ${{ inputs.test-e2e == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # uses: woocommerce/grow/run-qit-annotate@actions-v2
+      # Temporarily using test build
+      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
       with:
         type: e2e
         extension: ${{ inputs.extension }}

--- a/packages/github-actions/actions/run-qit-extension/action.yml
+++ b/packages/github-actions/actions/run-qit-extension/action.yml
@@ -72,7 +72,7 @@ runs:
 
     - name: Download `gha-dev-build`
       if: ${{ inputs.version == 'dev' }}
-      uses: robinraju/release-downloader@v1.8
+      uses: robinraju/release-downloader@v1.10
       with:
         repository: "woocommerce/${{ inputs.extension }}"
         tag: 'gha-dev-build'
@@ -93,7 +93,7 @@ runs:
     - name: Activation test
       id: activation
       if: ${{ inputs.test-activation == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v1
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: activation
         extension: ${{ inputs.extension }}
@@ -105,7 +105,7 @@ runs:
     - name: Security test
       id: security
       if: ${{ inputs.test-security == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v1
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: security
         extension: ${{ inputs.extension }}
@@ -117,7 +117,7 @@ runs:
     - name: PHPStan test
       id: phpstan
       if: ${{ inputs.test-phpstan == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v1
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: phpstan
         extension: ${{ inputs.extension }}
@@ -129,7 +129,7 @@ runs:
     - name: API test
       id: api
       if: ${{ inputs.test-api == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v1
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: api
         extension: ${{ inputs.extension }}
@@ -141,7 +141,7 @@ runs:
     - name: E2E test
       id: e2e
       if: ${{ inputs.test-e2e == 'true' }}
-      uses: woocommerce/grow/run-qit-annotate@actions-v1
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: e2e
         extension: ${{ inputs.extension }}

--- a/packages/github-actions/actions/run-qit-extension/action.yml
+++ b/packages/github-actions/actions/run-qit-extension/action.yml
@@ -93,9 +93,7 @@ runs:
     - name: Activation test
       id: activation
       if: ${{ inputs.test-activation == 'true' }}
-      # uses: woocommerce/grow/run-qit-annotate@actions-v2
-      # Temporarily using test build
-      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: activation
         extension: ${{ inputs.extension }}
@@ -107,9 +105,7 @@ runs:
     - name: Security test
       id: security
       if: ${{ inputs.test-security == 'true' }}
-      # uses: woocommerce/grow/run-qit-annotate@actions-v2
-      # Temporarily using test build
-      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: security
         extension: ${{ inputs.extension }}
@@ -121,9 +117,7 @@ runs:
     - name: PHPStan test
       id: phpstan
       if: ${{ inputs.test-phpstan == 'true' }}
-      # uses: woocommerce/grow/run-qit-annotate@actions-v2
-      # Temporarily using test build
-      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: phpstan
         extension: ${{ inputs.extension }}
@@ -135,9 +129,7 @@ runs:
     - name: API test
       id: api
       if: ${{ inputs.test-api == 'true' }}
-      # uses: woocommerce/grow/run-qit-annotate@actions-v2
-      # Temporarily using test build
-      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: api
         extension: ${{ inputs.extension }}
@@ -149,9 +141,7 @@ runs:
     - name: E2E test
       id: e2e
       if: ${{ inputs.test-e2e == 'true' }}
-      # uses: woocommerce/grow/run-qit-annotate@actions-v2
-      # Temporarily using test build
-      uses: woocommerce/grow/run-qit-annotate@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
+      uses: woocommerce/grow/run-qit-annotate@actions-v2
       with:
         type: e2e
         extension: ${{ inputs.extension }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR upgrades the `run-qit-extension` action to use Node.js v20.

#### 📌 Checklist before merging (@eason9487)

- [x] Revert f0b21e071cad4684f5cf68236c5ac7b2ce9c7cbf before merging this PR


### Detailed test instructions:

1. View a previous workflow run used v1 action
   - https://github.com/woocommerce/grow/actions/runs/8828789841
   - Some jobs failed due to accessing private repos with GitHub Actions bot token
   - There are warnings of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/1d6d3410-325e-4871-9eba-58bc244bb799)
2. View a test workflow run used updated action
   - https://github.com/woocommerce/grow/actions/runs/8829374140
   - There's no more warning of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/1431e11d-dbec-433c-a558-e4cb67396cd8)