### PR TITLE
Upgrade the `merge-trunk-develop-pr`, `prepare-extension-release`, and `publish-extension-dev-build` actions to use Node.js v20

### DIFF
--- a/packages/github-actions/actions/merge-trunk-develop-pr/README.md
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/README.md
@@ -24,5 +24,5 @@ jobs:
   automerge_trunk:
     runs-on: ubuntu-latest
     steps:
-      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v1
+      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v2
 ```

--- a/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: "Make the PR"
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const title = '${{github.event.pull_request.title}} - Merge `trunk` to `develop`';

--- a/packages/github-actions/actions/prepare-extension-release/README.md
+++ b/packages/github-actions/actions/prepare-extension-release/README.md
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: woocommerce/grow/prepare-extension-release@actions-v1
+        uses: actions/checkout@v4
+      - uses: woocommerce/grow/prepare-extension-release@actions-v2
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/packages/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/github-actions/actions/prepare-extension-release/action.yml
@@ -53,7 +53,7 @@ runs:
         git push --set-upstream origin ${{ steps.release-vars.outputs.branch }}
     - name: Create a pull request for the release
       id: prepare-release-pr
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const action_path = '${{ github.action_path }}';

--- a/packages/github-actions/actions/publish-extension-dev-build/README.md
+++ b/packages/github-actions/actions/publish-extension-dev-build/README.md
@@ -24,7 +24,7 @@ jobs:
       # build extension
       - run: npm run build
 
-      - uses: woocommerce/grow/publish-extension-dev-build@actions-v1
+      - uses: woocommerce/grow/publish-extension-dev-build@actions-v2
         with:
           extension-asset-path: my-extension.zip
 

--- a/packages/github-actions/actions/publish-extension-dev-build/action.yml
+++ b/packages/github-actions/actions/publish-extension-dev-build/action.yml
@@ -23,9 +23,7 @@ runs:
   steps:
     # Get unreleased notes
     - id: unreleased-notes
-      # uses: woocommerce/grow/get-release-notes@actions-v2
-      # Temporarily using test build
-      uses: woocommerce/grow/get-release-notes@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
+      uses: woocommerce/grow/get-release-notes@actions-v2
       with:
         repo-token: ${{ github.token }}
         tag-template: "{version}"

--- a/packages/github-actions/actions/publish-extension-dev-build/action.yml
+++ b/packages/github-actions/actions/publish-extension-dev-build/action.yml
@@ -23,13 +23,13 @@ runs:
   steps:
     # Get unreleased notes
     - id: unreleased-notes
-      uses: woocommerce/grow/get-release-notes@actions-v1
+      uses: woocommerce/grow/get-release-notes@actions-v2
       with:
         repo-token: ${{ github.token }}
         tag-template: "{version}"
 
     # Publish the build to GitHub
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       with:
         # The main action inputs are not accessible within the "script" input of actions/github-script.
         # So it needs to do forwarding.

--- a/packages/github-actions/actions/publish-extension-dev-build/action.yml
+++ b/packages/github-actions/actions/publish-extension-dev-build/action.yml
@@ -23,7 +23,9 @@ runs:
   steps:
     # Get unreleased notes
     - id: unreleased-notes
-      uses: woocommerce/grow/get-release-notes@actions-v2
+      # uses: woocommerce/grow/get-release-notes@actions-v2
+      # Temporarily using test build
+      uses: woocommerce/grow/get-release-notes@update/108-nodejs-v20-github-actions-get-plugin-releases-test-build
       with:
         repo-token: ${{ github.token }}
         tag-template: "{version}"

--- a/packages/github-actions/actions/publish-extension-dev-build/src/publish-extension-dev-build.js
+++ b/packages/github-actions/actions/publish-extension-dev-build/src/publish-extension-dev-build.js
@@ -7,7 +7,7 @@ import path from 'node:path';
 /**
  * Internal dependencies
  */
-import handleActionErrors from '../../../utils/handle-action-errors';
+import handleActionErrors from '../../../utils/handle-action-errors.js';
 
 export default async ( { github, context, core, changelog, inputs } ) => {
 	const { repos, git } = github.rest;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR upgrades the `merge-trunk-develop-pr`, `prepare-extension-release`, and `publish-extension-dev-build` actions to use Node.js v20.

#### 📌 Checklist before merging (@eason9487)

- [x] Revert 3f7ee00d93ac661ee0bd3f1cbd72316f4ff8333b before merging this PR

### Detailed test instructions:

#### `prepare-extension-release` action

1. View a previous workflow run used v1 action
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/8794326378
   - There are warnings of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/9432cf81-78b3-455f-8033-58ea3e0a6eac)
2. View a test workflow run used updated action
   - https://github.com/eason9487/grow/actions/runs/8830586225
   - There's no more warning of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/6d608d17-3651-41cb-810a-c15e7bcb56b2)
3. View the new release PR created by this action
   - https://github.com/eason9487/grow/pull/18

#### `merge-trunk-develop-pr` action

1. View a previous workflow run used v1 action
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/8794629482
   - There are warnings of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/414600ec-85f9-4314-8a54-fdfc5811bfdc)
2. View a test workflow run used updated action
   - https://github.com/eason9487/grow/actions/runs/8830610829
   - There's no more warning of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/d550535c-4f99-4073-a419-b46e7134464e)
3. View the merging back PR created by this action
   - https://github.com/eason9487/grow/pull/19

#### `publish-extension-dev-build` action

1. View a previous workflow run used v1 action
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/8796669445
   - There are warnings of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/ca065ae0-a8df-44b9-a4cf-c72b230d9973)
      (`woocommerce/grow/get-release-notes@actions-v1 and `actions/github-script@v6`)
2. View a test workflow run used updated action
   - https://github.com/eason9487/grow/actions/runs/8830553471
   - There's no more warning of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/be04d9bf-8216-469d-9ca8-198f25fee8ae)
3. View the dev build published by this action
   - https://github.com/eason9487/grow/releases/tag/test-gha-dev-build
      ![image](https://github.com/woocommerce/grow/assets/17420811/3336be0c-5eb8-4510-9acb-7a806cdaef81)
