### PR TITLE
Upgrade the `branch-label` action to use Node.js v20

### DIFF
--- a/packages/github-actions/actions/branch-label/README.md
+++ b/packages/github-actions/actions/branch-label/README.md
@@ -17,12 +17,43 @@ See [action.yml](action.yml)
 
 ```yaml
 on:
-  pull_request:
+  pull_request_target:
     types: opened
+
 jobs:
   SetLabels:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v1
+        uses: woocommerce/grow/branch-label@actions-v2
+```
+
+#### Permissions:
+
+It's recommended to use the `pull_request_target` event instead of `pull_request` to avoid the issue of not having permission to add labels to pull requests.
+
+Ref:
+- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+- https://github.com/actions/labeler/tree/v5#permissions
+
+## Migration from v1 to v2:
+
+```diff
+-  pull_request:
++  pull_request_target:
+     types: opened
+
+ jobs:
+   SetLabels:
++    permissions:
++      contents: read
++      pull-requests: write
+     runs-on: ubuntu-latest
+     steps:
+       - name: Set Labels
+-        uses: woocommerce/grow/branch-label@actions-v1
++        uses: woocommerce/grow/branch-label@actions-v2
 ```

--- a/packages/github-actions/actions/branch-label/README.md
+++ b/packages/github-actions/actions/branch-label/README.md
@@ -33,10 +33,11 @@ jobs:
 
 #### Permissions:
 
-It's recommended to use the `pull_request_target` event instead of `pull_request` to avoid the issue of not having permission to add labels to pull requests.
+In order to add labels to pull requests, this action requires write permissions on the pull request. However, when the action runs on a pull request from a fork, GitHub only grants read access tokens for the `pull_request` event. Therefore, it's recommended to use the `pull_request_target` event instead of `pull_request` to avoid the issue of not having permission.
 
 Ref:
 - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+- https://github.com/actions/labeler/tree/v5#usage
 - https://github.com/actions/labeler/tree/v5#permissions
 
 ## Migration from v1 to v2:

--- a/packages/github-actions/actions/branch-label/action.yml
+++ b/packages/github-actions/actions/branch-label/action.yml
@@ -4,46 +4,11 @@ description: Set PR labels according to the branch name.
 runs:
   using: composite
   steps:
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'breaking/') }}
-      with:
-        labels: |
-          changelog: breaking
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'add/') }}
-      with:
-        labels: |
-          type: enhancement
-          changelog: add
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'update/') }}
-      with:
-        labels: |
-          changelog: update
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'fix/') }}
-      with:
-        labels: |
-          type: bug
-          changelog: fix
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'tweak/') }}
-      with:
-        labels: |
-          changelog: tweak
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'dev/') }}
-      with:
-        labels: |
-          changelog: dev
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'doc/') }}
-      with:
-        labels: |
-          changelog: doc
-          type: documentation
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.head_ref, 'release/') }}
-      with:
-        labels: |
-          changelog: none
+    # Copy labeler.yml to the default config path of `actions/labeler`.
+    - shell: bash
+      run: |
+        CONFIG_DIR=.github
+        mkdir -p "$CONFIG_DIR"
+        cp "${{ github.action_path }}/labeler.yml" "$CONFIG_DIR"
+
+    - uses: actions/labeler@v5

--- a/packages/github-actions/actions/branch-label/labeler.yml
+++ b/packages/github-actions/actions/branch-label/labeler.yml
@@ -1,0 +1,27 @@
+"changelog: breaking":
+  - head-branch: "^breaking/"
+
+"changelog: add": &head-branch-add
+  - head-branch: "^add/"
+
+"changelog: update":
+  - head-branch: "^update/"
+
+"changelog: fix": &head-branch-fix
+  - head-branch: "^fix/"
+
+"changelog: tweak":
+  - head-branch: "^tweak/"
+
+"changelog: dev":
+  - head-branch: "^dev/"
+
+"changelog: doc": &head-branch-doc
+  - head-branch: "^doc/"
+
+"changelog: none":
+  - head-branch: "^release/"
+
+"type: enhancement": *head-branch-add
+"type: bug": *head-branch-fix
+"type: documentation": *head-branch-doc


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR upgrades the `branch-label` action to use Node.js v20.
- The `actions-ecosystem/action-add-labels` action has not been updated for almost 4 years. Therefore, this PR changes to use an alternative `actions/labeler` action to achieve the same function.
- In addition, to avoid the issue of not having permission to add labels to pull requests, the example changes the recommended event to the `pull_request_target` instead of `pull_request`.

### Detailed test instructions:

#### 📌 Using Node.js v20

1. View a previous workflow run used v1 action
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/8826963398
   - There are warnings of using Node.js 16 or even Node.js 12
      ![image](https://github.com/woocommerce/grow/assets/17420811/b2545c10-a704-46eb-8e36-03a70d342deb)
2. View test workflow runs used updated action
   - https://github.com/eason9487/grow/actions/runs/8845076148
   - There's no more warning of using Node.js 16
      ![image](https://github.com/woocommerce/grow/assets/17420811/9327206e-65fc-4d74-86f3-691b480dd91d)

#### 📌 View testing PRs to see if the alternative implementation can achieve the same results

#### 1️⃣ Add a label: https://github.com/eason9487/grow/pull/24

![image](https://github.com/woocommerce/grow/assets/17420811/abc7e45a-0b51-4689-961a-e04435ccd918)

#### 2️⃣ Add multiple labels: https://github.com/eason9487/grow/pull/25

![image](https://github.com/woocommerce/grow/assets/17420811/a3d50b38-a60e-43d7-8cda-f03050400a9b)

#### 3️⃣ Mismatched branch name: https://github.com/eason9487/grow/pull/26

No labels are added because the branch name `fixed/space-time-rift` didn't match any rules.

![image](https://github.com/woocommerce/grow/assets/17420811/37b34c22-32d5-4815-8056-8158db9d2ea6)

#### 4️⃣ No required permissions: https://github.com/eason9487/grow/pull/29

This test explains that [a workflow uses `pull_request` event](https://github.com/eason9487/grow/blob/fbfea2d2d8946ba72356ab8c71e7a9d92fc6f4d5/.github/workflows/test-github-actions-branch-label.yml#L3-L10) may result in permission issue when a PR is created from forks.

![image](https://github.com/woocommerce/grow/assets/17420811/47ebfe01-1cff-4de9-8431-72df215fb461)
![image](https://github.com/woocommerce/grow/assets/17420811/04b8a295-2017-4090-a482-c942f54f9ddd)
