### PR TITLE
Fixes admin notices not removed on plugin deactivation

### DIFF
--- a/packages/php/compat-checker/src/Checker.php
+++ b/packages/php/compat-checker/src/Checker.php
@@ -85,10 +85,10 @@ class Checker {
 		// Remove dismissable notices on plugin deactivation.
 		register_deactivation_hook(
 			$plugin_file_path,
-			array(
+			[
 				WCCompatibility::instance( $plugin_basename ),
 				'remove_dismissable_notices',
-			)
+			]
 		);
 
 		// Run all compatibility checks.

--- a/packages/php/compat-checker/src/Checker.php
+++ b/packages/php/compat-checker/src/Checker.php
@@ -81,7 +81,17 @@ class Checker {
 		];
 		$plugin_data     = $this->get_plugin_data( $plugin_file_path, $file_version );
 		$plugin_basename = plugin_basename( $plugin_file_path );
+		
+		// Remove dismissable notices on plugin deactivation.
+		register_deactivation_hook(
+			$plugin_file_path,
+			array(
+				WCCompatibility::instance( $plugin_basename ),
+				'remove_dismissable_notices',
+			)
+		);
 
+		// Run all compatibility checks.
 		foreach ( $checks as $compatibility ) {
 			if ( ! $compatibility::instance( $plugin_basename )->is_compatible( $plugin_data ) ) {
 				return false;

--- a/packages/php/compat-checker/src/Checker.php
+++ b/packages/php/compat-checker/src/Checker.php
@@ -81,7 +81,7 @@ class Checker {
 		];
 		$plugin_data     = $this->get_plugin_data( $plugin_file_path, $file_version );
 		$plugin_basename = plugin_basename( $plugin_file_path );
-		
+
 		// Remove dismissable notices on plugin deactivation.
 		register_deactivation_hook(
 			$plugin_file_path,

--- a/packages/php/compat-checker/src/Checks/CompatCheck.php
+++ b/packages/php/compat-checker/src/Checks/CompatCheck.php
@@ -172,4 +172,19 @@ abstract class CompatCheck {
 		add_action( 'admin_notices', [ $this, 'display_admin_notices' ], 20 );
 		return $this->run_checks();
 	}
+
+	/**
+	 * Remove dismissable notices.
+	 */
+	public function remove_dismissable_notices() {
+		if ( class_exists( WC_Admin_Notices::class ) ) {
+			$plugin_basename = plugin_basename( $this->plugin_data['File'] );
+			$all_notices     = WC_Admin_Notices::get_notices();
+			foreach ( $all_notices as $notice_name ) {
+				if ( true === str_starts_with( $notice_name, $plugin_basename ) ) {
+					WC_Admin_Notices::remove_notice( $notice_name );
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #94.

This PR registers a deactivation hook to remove dismissable notices added by `WC_Admin_Notices`.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Admin notices not removed on plugin deactivation
