### PR TITLE
Adds support for PHP < 8.0

### DIFF
--- a/packages/php/compat-checker/src/Checks/CompatCheck.php
+++ b/packages/php/compat-checker/src/Checks/CompatCheck.php
@@ -181,7 +181,7 @@ abstract class CompatCheck {
 			$plugin_basename = plugin_basename( $this->plugin_data['File'] );
 			$all_notices     = WC_Admin_Notices::get_notices();
 			foreach ( $all_notices as $notice_name ) {
-				if ( true === str_starts_with( $notice_name, $plugin_basename ) ) {
+				if ( 0 === strpos( $notice_name, $plugin_basename ) ) {
 					WC_Admin_Notices::remove_notice( $notice_name );
 				}
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

PR: #125 uses `str_starts_with` function is available only for PHP versions greater than `8.0`. This PR replaces `str_starts_with` with `strpos` function.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Support for PHP < 8.0
