### PR TITLE
Update QIT test types `api` and `e2e` for the `run-qit-extension` action to align with the renamed types

### DIFF
--- a/packages/github-actions/actions/run-qit-extension/action.yml
+++ b/packages/github-actions/actions/run-qit-extension/action.yml
@@ -127,11 +127,11 @@ runs:
         options: ${{ inputs.options }}
 
     - name: API test
-      id: woo-api
+      id: api
       if: ${{ inputs.test-api == 'true' }}
       uses: woocommerce/grow/run-qit-annotate@actions-v1
       with:
-        type: api
+        type: woo-api
         extension: ${{ inputs.extension }}
         extension-file: ${{ env.dev_build }}
         wait: ${{ inputs.wait }}

--- a/packages/github-actions/actions/run-qit-extension/action.yml
+++ b/packages/github-actions/actions/run-qit-extension/action.yml
@@ -127,7 +127,7 @@ runs:
         options: ${{ inputs.options }}
 
     - name: API test
-      id: api
+      id: woo-api
       if: ${{ inputs.test-api == 'true' }}
       uses: woocommerce/grow/run-qit-annotate@actions-v1
       with:
@@ -143,7 +143,7 @@ runs:
       if: ${{ inputs.test-e2e == 'true' }}
       uses: woocommerce/grow/run-qit-annotate@actions-v1
       with:
-        type: e2e
+        type: woo-e2e
         extension: ${{ inputs.extension }}
         extension-file: ${{ env.dev_build }}
         wait: ${{ inputs.wait }}


### PR DESCRIPTION
The QIT test types `api` and `e2e` have been renamed to `woo-api` and `woo-e2e`, this PR just updates the CI script to the new values to avoid failures as `e2e` will from now on refer to the [Custom E2E Test Type](https://qit.woo.com/docs/category/custom-tests).

Thanks!