### PR TITLE
Upgrade the templates to use the latest versions of GitHub actions in the JS package `generator-grow`

### DIFF
--- a/packages/js/generator-grow/generators/github/templates/workflows/branch-labels.yml
+++ b/packages/js/generator-grow/generators/github/templates/workflows/branch-labels.yml
@@ -1,11 +1,15 @@
 name: Set PR Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types: opened
+
 jobs:
   SetLabels:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v1
+        uses: woocommerce/grow/branch-label@actions-v2

--- a/packages/js/generator-grow/generators/phpcs/templates/php-coding-standards-diff.yml
+++ b/packages/js/generator-grow/generators/phpcs/templates/php-coding-standards-diff.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run PHPCS to changed lines of code
-        uses: woocommerce/grow/phpcs-diff@actions-v1
+        uses: woocommerce/grow/phpcs-diff@actions-v2
         with:
           php-version: <%= phpVersion %>

--- a/packages/js/generator-grow/generators/phpcs/templates/php-coding-standards.yml
+++ b/packages/js/generator-grow/generators/phpcs/templates/php-coding-standards.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           php-version: <%= phpVersion %>
           tools: cs2pr


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #108

This PR upgrades the templates to use the latest versions of GitHub actions in the JS package `generator-grow`

### Detailed test instructions:

1. View code changes
   - The [migration from v1 to v2](https://github.com/woocommerce/grow/tree/424eada2c2806c5635d1467e2fa494e9ba2a992c/packages/github-actions/actions/branch-label#migration-from-v1-to-v2) of `branch-label` action
2. Search the code within the `packages/js/generator-grow/generators` directory to see if there are all GitHub actions were upgraded
