### PR TITLE
Remove the unused step `id` from the `run-qit-extension` action

### DIFF
--- a/packages/github-actions/actions/run-qit-extension/action.yml
+++ b/packages/github-actions/actions/run-qit-extension/action.yml
@@ -91,7 +91,6 @@ runs:
           --qit_token='${{ inputs.qit-partner-secret }}'
 
     - name: Activation test
-      id: activation
       if: ${{ inputs.test-activation == 'true' }}
       uses: woocommerce/grow/run-qit-annotate@actions-v1
       with:
@@ -103,7 +102,6 @@ runs:
         options: ${{ inputs.options }}
 
     - name: Security test
-      id: security
       if: ${{ inputs.test-security == 'true' }}
       uses: woocommerce/grow/run-qit-annotate@actions-v1
       with:
@@ -115,7 +113,6 @@ runs:
         options: ${{ inputs.options }}
 
     - name: PHPStan test
-      id: phpstan
       if: ${{ inputs.test-phpstan == 'true' }}
       uses: woocommerce/grow/run-qit-annotate@actions-v1
       with:
@@ -127,7 +124,6 @@ runs:
         options: ${{ inputs.options }}
 
     - name: API test
-      id: api
       if: ${{ inputs.test-api == 'true' }}
       uses: woocommerce/grow/run-qit-annotate@actions-v1
       with:
@@ -139,7 +135,6 @@ runs:
         options: ${{ inputs.options }}
 
     - name: E2E test
-      id: e2e
       if: ${{ inputs.test-e2e == 'true' }}
       uses: woocommerce/grow/run-qit-annotate@actions-v1
       with:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In PR #127, the QIT test types `api` and `e2e` were renamed. After renaming, they are inconsistent with corresponding `steps.<step_id>`.

Upon further checking, it appears that these `steps.<step_id>` are not being used. This PR removes them from the `run-qit-extension` action.

Ref: https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context

### Detailed test instructions:

1. View the commit 82a27abff498dce7c8aa1dbf1070bea85de72153 triggered a workflow run to validate the `run-qit-extension` action of this PR
2. View the result of [the test workflow run](https://github.com/woocommerce/grow/actions/runs/9059164143)

