### PR TITLE
Avoid running malicious inputs as shell commands in Custom GitHub actions and relate workflows

### DIFF
--- a/.github/workflows/github-actions-create-test-build.yml
+++ b/.github/workflows/github-actions-create-test-build.yml
@@ -20,9 +20,10 @@ jobs:
           install-deps: "no"
 
       - name: Create and commit test build
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           REPO_URL="${{ github.server_url }}/${{ github.repository }}"
-          BRANCH_NAME="${{ github.ref_name }}"
           TEST_BRANCH_NAME="${BRANCH_NAME}-test-build"
 
           .github/scripts/github-actions-create-and-commit-build.sh "$REPO_URL" "$BRANCH_NAME"

--- a/.github/workflows/github-actions-delete-test-build.yml
+++ b/.github/workflows/github-actions-delete-test-build.yml
@@ -15,8 +15,9 @@ jobs:
           ref: trunk
 
       - name: Delete test build branch
+        env:
+          BRANCH_NAME: ${{ format('{0}-test-build', github.event.ref) }}
         run: |
-          BRANCH_NAME="${{ github.event.ref }}-test-build"
           REMOTE_BRANCH_NAME="origin/${BRANCH_NAME}"
 
           git fetch --prune --no-tags --depth=1 origin

--- a/packages/github-actions/actions/automerge-released-trunk/action.yml
+++ b/packages/github-actions/actions/automerge-released-trunk/action.yml
@@ -11,10 +11,12 @@ runs:
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}
       # Use the github-actions bot account to commit.
       # https://api.github.com/users/github-actions%5Bbot%5D
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
         git config user.name github-actions[bot]
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
         git fetch origin develop trunk --unshallow --no-tags
         git checkout develop
-        git merge --no-ff origin/trunk -m "Automerge ${{ github.head_ref }} from trunk to develop"
+        git merge --no-ff origin/trunk -m "Automerge ${HEAD_REF} from trunk to develop"
         git push

--- a/packages/github-actions/actions/eslint-annotation/action.yml
+++ b/packages/github-actions/actions/eslint-annotation/action.yml
@@ -11,8 +11,9 @@ runs:
   steps:
     # Copy formatter script to the destination file path.
     - shell: bash
+      env:
+        SCRIPT_DEST: ${{ inputs.formatter-dest }}
       run: |
-        SCRIPT_DEST="${{ inputs.formatter-dest }}"
         mkdir -p $(dirname "$SCRIPT_DEST")
         echo '/* eslint-disable */' > "$SCRIPT_DEST"
         cat "${{ github.action_path }}/eslintFormatter.cjs" >> "$SCRIPT_DEST"

--- a/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
@@ -9,11 +9,11 @@ runs:
       uses: actions/github-script@v6
       with:
         script: |
-          const title = '${{github.event.pull_request.title}} - Merge `trunk` to `develop`';
+          const title = `${ context.payload.pull_request.title } - Merge \`trunk\` to \`develop\``;
           const opts = await github.rest.pulls.create( {
             ...context.repo,
             base: 'develop',
             head: 'trunk',
             title,
-            body: '${{ github.event.pull_request.html_url }}',
+            body: context.payload.pull_request.html_url,
           } );

--- a/packages/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/github-actions/actions/prepare-extension-release/action.yml
@@ -37,20 +37,25 @@ runs:
   steps:
     - name: Set release branch name
       id: release-vars
+      env:
+        INPUT_TYPE: ${{ inputs.type }}
+        INPUT_VERSION: ${{ inputs.version }}
       shell: bash
-      run: echo "branch=${{ inputs.type }}/${{ inputs.version }}" >> $GITHUB_OUTPUT
+      run: echo "branch=${INPUT_TYPE}/${INPUT_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Prepare release commits
+      env:
+        BRANCH_NAME: ${{ steps.release-vars.outputs.branch }}
       shell: bash
        # Use the github-actions bot account to commit.
        # https://api.github.com/users/github-actions%5Bbot%5D
       run: |
         git config user.name github-actions[bot]
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git checkout -b ${{ steps.release-vars.outputs.branch }}
+        git checkout -b "${BRANCH_NAME}"
 
-        git commit --allow-empty -q -m "Start \`${{ steps.release-vars.outputs.branch }}\`."
-        git push --set-upstream origin ${{ steps.release-vars.outputs.branch }}
+        git commit --allow-empty -q -m "Start \`${BRANCH_NAME}\`."
+        git push --set-upstream origin "${BRANCH_NAME}"
     - name: Create a pull request for the release
       id: prepare-release-pr
       uses: actions/github-script@v6
@@ -64,11 +69,9 @@ runs:
             context,
             github,
             inputs,
-            refName: '${{ steps.release-vars.outputs.branch }}'
+            refName: `${ inputs.type }/${ inputs.version }`,
           } );
     - name: Generate summary
       shell: bash
       run: |
         echo "Release PR created at ${{  fromJSON(steps.prepare-release-pr.outputs.result).html_url }}" >> $GITHUB_STEP_SUMMARY
-
-

--- a/packages/github-actions/actions/prepare-node/action.yml
+++ b/packages/github-actions/actions/prepare-node/action.yml
@@ -44,11 +44,11 @@ runs:
 
     # Install node dependencies.
     - shell: bash
+      env:
+        INSTALL_DEPS: ${{ inputs.install-deps }}
+        IGNORE_SCRIPTS: ${{ inputs.ignore-scripts }}
       # `actions/setup-node` should update npm cache directory if `package-lock` has changed.
       run: |
-        INSTALL_DEPS="${{ inputs.install-deps }}"
-        IGNORE_SCRIPTS="${{ inputs.ignore-scripts }}"
-
         COLOR_INFO="\033[38;5;39m"
         COLOR_END="\033[0m"
 

--- a/packages/github-actions/actions/prepare-php/action.yml
+++ b/packages/github-actions/actions/prepare-php/action.yml
@@ -58,8 +58,9 @@ runs:
 
     # Install Composer dependencies.
     - shell: bash
+      env:
+        INSTALL_DEPS: ${{ inputs.install-deps }}
       run: |
-        INSTALL_DEPS="${{ inputs.install-deps }}"
         COMPOSER_VER=$(composer --version | awk '{ print $3 }')
 
         COLOR_INFO="\033[38;5;39m"

--- a/packages/github-actions/actions/run-qit-annotate/action.yml
+++ b/packages/github-actions/actions/run-qit-annotate/action.yml
@@ -58,11 +58,14 @@ runs:
         zip: ${{ inputs.extension-file &&  format('--zip={0}', inputs.extension-file) || '' }}
         wait: ${{ inputs.wait == 'true' && '--wait' || '' }}
         ignore_fail: ${{ inputs.ignore-fail == 'true' && '--ignore-fail' || '' }}
+        type: ${{ inputs.type }}
+        extension: ${{ inputs.extension }}
+        options: ${{ inputs.options }}
       run: |
-        json=`./vendor/bin/qit run:${{ inputs.type }} \
-         ${{ inputs.extension }} \
+        json=`./vendor/bin/qit run:${type} \
+         ${extension} \
          $zip \
-         ${{ inputs.options }} \
+         ${options} \
          $wait \
          $ignore_fail \
          -n \
@@ -85,8 +88,10 @@ runs:
     # Annotate the results according to the status, forward qit exit code.
     - name: Annotate and exit
       shell: bash
+      env:
+        type: ${{ inputs.type }}
       run: |
-        summary="${{ inputs.type }} (${{ steps.read-summary.outputs.test_run_id }}): ${{ steps.read-summary.outputs.status }} - ${{ steps.read-summary.outputs.summary }} \`qit get ${{ steps.read-summary.outputs.test_run_id }}\`";
+        summary="${type} (${{ steps.read-summary.outputs.test_run_id }}): ${{ steps.read-summary.outputs.status }} - ${{ steps.read-summary.outputs.summary }} \`qit get ${{ steps.read-summary.outputs.test_run_id }}\`";
         case ${{ steps.read-summary.outputs.status }} in
           "success") echo "::notice ::$summary"
           ;;

--- a/packages/github-actions/actions/stylelint-annotation/action.yml
+++ b/packages/github-actions/actions/stylelint-annotation/action.yml
@@ -11,8 +11,9 @@ runs:
   steps:
     # Copy formatter script to the destination file path.
     - shell: bash
+      env:
+        SCRIPT_DEST: ${{ inputs.formatter-dest }}
       run: |
-        SCRIPT_DEST="${{ inputs.formatter-dest }}"
         mkdir -p $(dirname "$SCRIPT_DEST")
         echo '/* eslint-disable */' > "$SCRIPT_DEST"
         cat "${{ github.action_path }}/stylelintFormatter.cjs" >> "$SCRIPT_DEST"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR avoids running malicious inputs as shell commands in the GitHub Actions.

Although the most input values are entered by devs who have access to their repo, which means it's almost unlikely to be vulnerable to such attacks, it would be better to fix it.

Ref: https://securitylab.github.com/research/github-actions-untrusted-input/

### Detailed test instructions:

#### 📌 Workflows for managing test build

1. View [the run result of "Create Test Build"](https://github.com/eason9487/grow/actions/runs/9092740515/job/24990117967#step:4:509)
   ![image](https://github.com/woocommerce/grow/assets/17420811/52794dd8-de8f-4157-8c02-890ae2ca5448)
2. View [the run result of "Delete Test Build"](https://github.com/eason9487/grow/actions/runs/9092758668/job/24990178123#step:3:28)
   ![image](https://github.com/woocommerce/grow/assets/17420811/b3c7a30a-c339-4c0d-84e7-ae5fd775f865)

#### 📌 `automerge-released-trunk` action

I don't prepare a test for this as it uses the same fix as https://github.com/woocommerce/google-listings-and-ads/pull/2394

#### 📌 `eslint-annotation` and `stylelint-annotation` actions

1. View [the test workflow run](https://github.com/woocommerce/automatewoo-birthdays/actions/runs/9093215211) used fixed `eslint-annotation` and `stylelint-annotation` actions
   ![image](https://github.com/woocommerce/grow/assets/17420811/97319a50-fd53-463b-b86d-7eb5f7d9be46)
   - This run failed on purpose to test if it can report JS and CSS linting errors
2. View linting annotations in [the test PR](https://github.com/woocommerce/automatewoo-birthdays/pull/134)
   ![image](https://github.com/woocommerce/grow/assets/17420811/4a7b7cab-fb1e-4079-a26c-a1a13b77259b)
   ![image](https://github.com/woocommerce/grow/assets/17420811/54ecc879-3b13-46a3-a00d-b9dfe80e17bd)

#### 📌 `prepare-extension-release` action

1. View [the test workflow run](https://github.com/eason9487/grow/actions/runs/8830586225) used fixed action
   ![1](https://github.com/woocommerce/grow/assets/17420811/e1d44017-ca66-4f7a-89d2-42d1468f0208)
2. View [the new release PR](https://github.com/eason9487/grow/pull/34) created by this action

#### 📌 `merge-trunk-develop-pr` actions

1. View [the test workflow run](https://github.com/eason9487/grow/actions/runs/9094206694) used fixed action
   ![image](https://github.com/woocommerce/grow/assets/17420811/146efe39-4c6c-4dc2-bde5-3d0a789f7b7b)
2. View [the merging back PR](https://github.com/eason9487/grow/pull/35) created by this action

#### 📌 `prepare-node` and `prepare-php` actions

1. View the [run result of "Create Test Build"](https://github.com/eason9487/grow/actions/runs/9092740515/job/24990117967#step:3:54) as it also use the `prepare-node` action.
   ![image](https://github.com/woocommerce/grow/assets/17420811/d40aeaae-ebb9-465a-ab2d-ef54ab5d7fa3)
3. The `prepare-php` action uses the same fix so I believe it should work as well.

#### 📌 `run-qit-annotate` action

1. View the commit 3393d60b679bdb01ea891a3f49f36c9a9b3ccdb1 triggered a workflow run to validate the `run-qit-annotate` action of this PR
3. View the result of [the test workflow run](https://github.com/woocommerce/grow/actions/runs/9093867368)
   ![image](https://github.com/woocommerce/grow/assets/17420811/edadc9f0-4228-4e65-b66b-212d83a7045e)
   ![image](https://github.com/woocommerce/grow/assets/17420811/683c47e0-2b36-4338-adb1-66ec3f6f2b22)
