### PR TITLE
Upgrade the workflows in this repo's GitHub Actions to use Node.js v20

### DIFF
--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -27,15 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v1
+        uses: woocommerce/grow/prepare-node@actions-v2
         with:
           node-version-file: .nvmrc
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v1
+        uses: woocommerce/grow/eslint-annotation@actions-v2
 
       # Turn off import/no-unresolved rule since this check doesn't install packages for all sub-packages.
       - name: Lint JavaScript and annotate linting errors

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v1
+        uses: woocommerce/grow/prepare-php@actions-v2
         with:
           php-version: 7.4
           tools: cs2pr

--- a/.github/workflows/run-qit-all.yml
+++ b/.github/workflows/run-qit-all.yml
@@ -69,7 +69,7 @@ jobs:
             extension: [automatewoo, automatewoo-birthdays, automatewoo-referrals, google-listings-and-ads, woocommerce-google-analytics-integration]
         steps:
           - name: Run QIT
-            uses: woocommerce/grow/run-qit-extension@actions-v1
+            uses: woocommerce/grow/run-qit-extension@actions-v2
             with:
               qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
               qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It should be the last part of #108

This PR upgrades the workflows in this repo's GitHub Actions to use Node.js v20.

### Detailed test instructions:

View the [Checks](https://github.com/woocommerce/grow/pull/135/checks) tab to check if all checks have passed and if there are no longer deprecated warnings about Node.js <= 16

