### PR TITLE
[Revert] Update woo.com domain, update feature-requests URL in yeoman generator

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ The packages here are too experimental or too Grow-specific to be shared Woo-wid
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
-	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woocommerce.com/">Woo</a>.<br/>
+	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -183,6 +183,6 @@ Branch off from the old version, set the merge base for fixing PR to be the same
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
-	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woocommerce.com/">Woo</a>.<br/>
+	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -61,7 +61,7 @@ export default async ( { context, github, inputs, refName } ) => {
 1. [ ] Update documentation
    - [ ] Publish any new required docs
    - [ ] Update triggers/rules/actions listing pages
-1. [ ] Mark related ideas complete [on the feature requests page](https://woo.com/feature-requests/${ extensionPackageName }/).
+1. [ ] Mark related ideas complete [on the feature requests page](https://woocommerce.com/feature-requests/${ extensionPackageName }/).
 ${ postSteps }
 `;
 

--- a/packages/js/generator-grow/README.md
+++ b/packages/js/generator-grow/README.md
@@ -24,6 +24,6 @@ Or call task separately:
 
 <p align="center">
 	<br/><br/>
-	Made with 💜 by <a href="https://woo.com/">Woo</a>.<br/>
-	<a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
+	Made with 💜 by <a href="https://woocommerce.com/">Woo</a>.<br/>
+	<a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/packages/js/generator-grow/generators/github/github.test.js
+++ b/packages/js/generator-grow/generators/github/github.test.js
@@ -69,7 +69,7 @@ describe( ':github', function () {
 			.then( function () {
 				assert.fileContent(
 					'.github/CONTRIBUTING.md',
-					'https://woo.com/feature-requests/foo-bar'
+					'https://woocommerce.com/feature-requests/foo-bar'
 				);
 			} );
 	} );
@@ -83,7 +83,7 @@ describe( ':github', function () {
 
 				assert.fileContent(
 					'.github/CONTRIBUTING.md',
-					`https://woo.com/feature-requests/${ appname }`
+					`https://woocommerce.com/feature-requests/${ appname }`
 				);
 			} );
 	} );

--- a/packages/js/generator-grow/generators/github/templates/CODE_OF_CONDUCT.md
+++ b/packages/js/generator-grow/generators/github/templates/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/packages/js/generator-grow/generators/github/templates/CONTRIBUTING.md
+++ b/packages/js/generator-grow/generators/github/templates/CONTRIBUTING.md
@@ -16,4 +16,4 @@ Please see [SECURITY.md](./SECURITY.md).
 
 ## Feature Requests
 
-Feature requests can be submitted to our [feature requests page](https://woo.com/feature-requests/<%= slug %>/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.
+Feature requests can be submitted to our [feature requests page](https://woocommerce.com/feature-requests/<%= slug %>/). Be sure to include a good description of the expected behavior and use case, and before submitting a request, please search for similar ones.

--- a/packages/php/compat-checker/src/Checks/WCCompatibility.php
+++ b/packages/php/compat-checker/src/Checks/WCCompatibility.php
@@ -28,7 +28,7 @@ class WCCompatibility extends CompatCheck {
 	 *
 	 * @var int|float The miniumum supported WooCommerce versions before the latest.
 	 *
-	 * @see https://woo.com/support-policy/
+	 * @see https://woocommerce.com/support-policy/
 	 */
 	private $min_wc_semver = 0.2; // By default, the latest minus two version.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project: peeuvX-1zs-p2

This PR reverts part of the changes in https://github.com/woocommerce/grow/pull/88
that replaced woocommerce.com references with woo.com references.

So this PR will put back woocommerce.com as the domain.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm all changed URLs work.
2. Verify no woo.com references are left in the repo
3. Install the generator according to [its readme](https://github.com/woocommerce/grow/tree/trunk/packages/js/generator-grow#readme)
4. create a test directory
5. run yo grow there
6. Search for woocommerce.com. Check that feature requests link in .github/CONTRIBUTING.md works


### Additional details:


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak -  Replace woo.com references with woocommerce.com.