### PR TITLE
Add release confirmation step to extension release PR

### DIFF
--- a/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
+++ b/packages/github-actions/actions/prepare-extension-release/src/woo-extension-create-pr-for-release.mjs
@@ -55,6 +55,8 @@ export default async ( { context, github, inputs, refName } ) => {
    woorelease release --product_version=${ version } ${ testedVersions }  --generate_changelog ${ repoURL }
    \`\`\`
    When prompted for changelog entries, double-check and apply any changes if needed.
+1. [ ] Confirm the release using the activation link from your email.
+   When releasing to WordPress.org, _“release notifications”_ have been enabled, so each committer will be sent an email with an action link to confirm the release. This must be done after committing in SVN before the release becomes available. See the following page for releases pending notifications: https://wordpress.org/plugins/developers/releases/
 1. [ ] Go to ${ context.payload.repository.html_url }/releases/${ version }, generate GitHub release notes, and paste them as a comment here.
 1. [ ] Merge this PR after the new release is successfully created and the version tags are updated.
 1. [ ] Merge \`trunk\` to \`develop\` (PR), if applicable for this repo.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Add release confirmation step to extension release PR

Recently, the ["release notifications"](https://wordpress.org/plugins/developers/releases/) were enabled for WPORG plugins. This PR adds a step to confirm the release.

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
To create the PR and test it E2E we would need to (test) release it and use in a repo. 
As this PR does not change any logic related to PR creation, just the message, I hope proof-reading the new PR body would be enough.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Add release confirmation step to extension release PR checklist.
