### PR TITLE
Change the runners in the examples of QIT actions in the `github-actions` package to ubuntu-latest

### DIFF
--- a/packages/github-actions/actions/run-qit-annotate/README.md
+++ b/packages/github-actions/actions/run-qit-annotate/README.md
@@ -22,7 +22,7 @@ See [action.yml](action.yml)
 jobs:
   qit-test:
     name: Run QIT Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       QIT_DISABLE_ONBOARDING: yes
     steps:

--- a/packages/github-actions/actions/run-qit-extension/README.md
+++ b/packages/github-actions/actions/run-qit-extension/README.md
@@ -22,7 +22,7 @@ See [action.yml](action.yml)
 jobs:
   qit-test:
     name: Run QIT Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:    
       - name: Delegate QIT Tests
         uses: woocommerce/grow/run-qit-extension@actions-v2


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The GitHub-hosted Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. This PR changes the runners in the examples of QIT actions in the `github-actions` package from **ubuntu-20.04** to **ubuntu-latest**.

💡 I will be skipping code review since the change only involves documentation.
