### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/github-action-publish-compat-checker.yml
+++ b/.github/workflows/github-action-publish-compat-checker.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Deploy
-      uses: s0/git-publish-subdir-action@develop
+      uses: s0/git-publish-subdir-action@92faf786f11dfa44fc366ac3eb274d193ca1af7e # v.2.6.0
       env:
         REPO: self
         BRANCH: compat-checker

--- a/packages/github-actions/actions/coverage-report/action.yml
+++ b/packages/github-actions/actions/coverage-report/action.yml
@@ -42,7 +42,7 @@ runs:
 
     # Download coverage report artifact
     - if: github.event_name == 'pull_request'
-      uses: dawidd6/action-download-artifact@v3
+      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
       continue-on-error: true
       with:
         workflow: ${{ inputs.workflow }}
@@ -59,7 +59,7 @@ runs:
 
     # Coverage report as PR comment
     - if: github.event_name == 'pull_request'
-      uses: lucassabreu/comment-coverage-clover@main
+      uses: lucassabreu/comment-coverage-clover@6da350e7fff3254235663a409af8739e9d289d63 # v0.15.4
       with:
         file: "${{ inputs.report-path }}/${{ inputs.report-file }}"
         base-file: "${{ inputs.report-path }}/${{ inputs.base-branch }}/${{ inputs.report-file }}"

--- a/packages/github-actions/actions/run-qit-extension/action.yml
+++ b/packages/github-actions/actions/run-qit-extension/action.yml
@@ -75,7 +75,7 @@ runs:
 
     - name: Download `gha-dev-build`
       if: ${{ inputs.version == 'dev' }}
-      uses: robinraju/release-downloader@v1.10
+      uses: robinraju/release-downloader@c39a3b234af58f0cf85888573d361fb6fa281534 # v1.10
       with:
         repository: "woocommerce/${{ inputs.extension }}"
         tag: 'gha-dev-build'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [QAO-19](https://linear.app/a8c/issue/QAO-46/woocommercegrow-pin-github-actions-to-full-commit-sha)

Pins Github actions to full commit SHAs as immutable references.
Skipped all official GitHub actions.  
Used the latest commit in the tag that was already used, or the latest commit in the latest released tag where the branch name was used. This to reduce the risk of including breaking changes.

### Detailed test instructions:

To be tested after merge to trunk.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
[actions] changelog: Dev - Pinned GitHub actions.
>
