### PR TITLE
Update the release config to exclude the github-actions bot account from GitHub release notes

### DIFF
--- a/packages/github-actions/release-notes-config.yml
+++ b/packages/github-actions/release-notes-config.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     authors:
       - github-actions
+      - github-actions[bot]
     labels:
       - "changelog: none"
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the release config to exclude the github-actions bot account from GitHub release notes for the `github-actions` package.
