### PR TITLE
Release version 1.0.0 of the `tracking-jsdoc` package

### DIFF
--- a/packages/js/tracking-jsdoc/CHANGELOG.md
+++ b/packages/js/tracking-jsdoc/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2025-11-26 (1.0.0)
+### New Features 🎉
+* Add tracking JSDoc template and plugins. (https://github.com/woocommerce/grow/pull/6)
+* Add `jsdoc` bundle package (https://github.com/woocommerce/grow/pull/10)
+### Updated ✨
+* Upgrade the npm dependency `jsdoc` to v4 for the JS package `tracking-jsdoc` (https://github.com/woocommerce/grow/pull/103)
+* Upgrade JS packages `jsdoc` and `tracking-jsdoc` to use Node.js v20 (https://github.com/woocommerce/grow/pull/110)

--- a/packages/js/tracking-jsdoc/package.json
+++ b/packages/js/tracking-jsdoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-grow-tracking-jsdoc",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "JSDoc template to report Tracking events to markdown file",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 2025-11-26 (1.0.0)
### New Features 🎉
* Add tracking JSDoc template and plugins. (https://github.com/woocommerce/grow/pull/6)
* Add `jsdoc` bundle package (https://github.com/woocommerce/grow/pull/10)
### Updated ✨
* Upgrade the npm dependency `jsdoc` to v4 for the JS package `tracking-jsdoc` (https://github.com/woocommerce/grow/pull/103)
* Upgrade JS packages `jsdoc` and `tracking-jsdoc` to use Node.js v20 (https://github.com/woocommerce/grow/pull/110)
