### PR TITLE
Change the `tracking-jsdoc` dependency in grow's `jsdoc` package to install directly from GitHub

### DIFF
--- a/packages/js/jsdoc/package-lock.json
+++ b/packages/js/jsdoc/package-lock.json
@@ -14,7 +14,7 @@
         "jsdoc-plugin-intersection": "^1.0.4",
         "jsdoc-plugin-typescript": "^2.2.1",
         "shelljs": "^0.8.5",
-        "woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba"
+        "woocommerce-grow-tracking-jsdoc": "git+https://github.com/woocommerce/grow#tracking-jsdoc-v1"
       },
       "bin": {
         "woocommerce-grow-jsdoc": "bin/jsdoc.mjs"
@@ -1428,10 +1428,12 @@
       }
     },
     "node_modules/woocommerce-grow-tracking-jsdoc": {
-      "version": "0.0.2",
-      "resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba",
-      "integrity": "sha512-RMZecq3RbgutjnmAbrO0dLBQ/MX3i/kQXyHGeYITocOIDZIabUX6mvEEK2uHu2frtvAVn154u3upEMk7X8JZnw==",
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/woocommerce/grow.git#ac115c64c5427ae6b2a9d9ccd0498e82a1864a8e",
       "license": "GPL-3.0-or-later",
+      "engines": {
+        "node": ">=16"
+      },
       "peerDependencies": {
         "jsdoc": "^4.0.2"
       }

--- a/packages/js/jsdoc/package.json
+++ b/packages/js/jsdoc/package.json
@@ -27,6 +27,6 @@
     "jsdoc-plugin-intersection": "^1.0.4",
     "jsdoc-plugin-typescript": "^2.2.1",
     "shelljs": "^0.8.5",
-    "woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba"
+    "woocommerce-grow-tracking-jsdoc": "git+https://github.com/woocommerce/grow#tracking-jsdoc-v1"
   }
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since gitpkg.now.sh is unavailable, the dependency for `jsdoc` on `woocommerce-grow-tracking-jsdoc` cannot be installed. Therefore, this PR changes the installation source to this GitHub repository.

### Detailed test instructions:

1. `cd packages/js/jsdoc`
2. `npm install`
3. Delete some content from the `<woocommerce-grow-tracking-jsdoc>` tag in the`samples/jsdoc/TRACKING.md` file.
4. `npm run dev:doc:tracking`
5. View if it can generate tracking doc in the`samples/jsdoc/TRACKING.md` file
