### PR TITLE
Release version 1.0.0 of the `jsdoc` package

### DIFF
--- a/packages/js/jsdoc/CHANGELOG.md
+++ b/packages/js/jsdoc/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2025-11-26 (1.0.0)
+### New Features 🎉
+* Add `jsdoc` bundle package (https://github.com/woocommerce/grow/pull/10)
+* Forward args & source directory to `-jsdoc` binary. (https://github.com/woocommerce/grow/pull/13)
+### Updated ✨
+* Upgrade the npm dependency `jsdoc` to v4 for the JS package `tracking-jsdoc` (https://github.com/woocommerce/grow/pull/103)
+* Upgrade the npm dependency `jsdoc` to v4 for the JS package `jsdoc` (https://github.com/woocommerce/grow/pull/104)
+* Upgrade JS packages `jsdoc` and `tracking-jsdoc` to use Node.js v20 (https://github.com/woocommerce/grow/pull/110)
+* Change the `tracking-jsdoc` dependency in grow's `jsdoc` package to install directly from GitHub (https://github.com/woocommerce/grow/pull/182)

--- a/packages/js/jsdoc/package-lock.json
+++ b/packages/js/jsdoc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-grow-jsdoc",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-grow-jsdoc",
-      "version": "0.0.4",
+      "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "jsdoc": "^4.0.2",

--- a/packages/js/jsdoc/package.json
+++ b/packages/js/jsdoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-grow-jsdoc",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "Grow's JSDoc bundle to document tracking events",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 2025-11-26 (1.0.0)
### New Features 🎉
* Add `jsdoc` bundle package (https://github.com/woocommerce/grow/pull/10)
* Forward args & source directory to `-jsdoc` binary. (https://github.com/woocommerce/grow/pull/13)
### Updated ✨
* Upgrade the npm dependency `jsdoc` to v4 for the JS package `tracking-jsdoc` (https://github.com/woocommerce/grow/pull/103)
* Upgrade the npm dependency `jsdoc` to v4 for the JS package `jsdoc` (https://github.com/woocommerce/grow/pull/104)
* Upgrade JS packages `jsdoc` and `tracking-jsdoc` to use Node.js v20 (https://github.com/woocommerce/grow/pull/110)
* Change the `tracking-jsdoc` dependency in grow's `jsdoc` package to install directly from GitHub (https://github.com/woocommerce/grow/pull/182)