### PR TITLE
Fix linting errors for the `get-plugin-releases` action

### DIFF
--- a/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
+++ b/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
@@ -8,14 +8,6 @@ import core from '@actions/core';
  */
 import handleActionErrors from '../../../utils/handle-action-errors.js';
 
-async function getPluginReleases( inputs ) {
-	const apiEndpoint = getAPIEndpoint( inputs.slug );
-
-	return fetch( apiEndpoint )
-		.then( ( res ) => res.json() )
-		.then( ( data ) => parsePluginVersions( data, inputs ) );
-}
-
 function getAPIEndpoint( slug ) {
 	if ( slug === 'wordpress' ) {
 		return 'https://api.wordpress.org/core/version-check/1.7/';
@@ -40,6 +32,57 @@ function getInput( key ) {
 function setOutput( key, value ) {
 	core.info( `==> Output "${ key }":\n${ value }` );
 	core.setOutput( key, value );
+}
+
+function isRC( version ) {
+	return version.toLowerCase().includes( 'rc' );
+}
+
+function isMinorAlreadyAdded( output, version ) {
+	if (
+		output.find( ( el ) => {
+			const elSegments = el.split( '.' );
+			const versionSegments = version.split( '.' );
+			return (
+				elSegments[ 0 ] === versionSegments[ 0 ] &&
+				elSegments[ 1 ] === versionSegments[ 1 ]
+			);
+		} )
+	) {
+		return true;
+	}
+}
+
+function semverCompare( a, b ) {
+	const regex = /^(\d+)\.(\d+)\.(\d+)(-rc\.\d+)?$/;
+
+	const aMatches = a.toLowerCase().match( regex );
+	const [ , majorA, minorA, patchA, rcA ] = aMatches;
+
+	const bMatches = b.toLowerCase().match( regex );
+	const [ , majorB, minorB, patchB, rcB ] = bMatches;
+
+	if ( majorA !== majorB ) {
+		return majorB - majorA;
+	}
+	if ( minorA !== minorB ) {
+		return minorB - minorA;
+	}
+	if ( patchA !== patchB ) {
+		return patchB - patchA;
+	}
+
+	if ( ! rcA ) {
+		return -1;
+	}
+	if ( ! rcB ) {
+		return 1;
+	}
+
+	return (
+		parseInt( rcB.replace( '-rc.', '' ), 10 ) -
+		parseInt( rcA.replace( '-rc.', '' ), 10 )
+	);
 }
 
 function parsePluginVersions( releases = {}, inputs ) {
@@ -89,45 +132,12 @@ function parsePluginVersions( releases = {}, inputs ) {
 	setOutput( 'versions', output );
 }
 
-function isRC( version ) {
-	return version.toLowerCase().includes( 'rc' );
-}
+async function getPluginReleases( inputs ) {
+	const apiEndpoint = getAPIEndpoint( inputs.slug );
 
-function isMinorAlreadyAdded( output, version ) {
-	if (
-		output.find( ( el ) => {
-			const elSegments = el.split( '.' );
-			const versionSegments = version.split( '.' );
-			return (
-				elSegments[ 0 ] === versionSegments[ 0 ] &&
-				elSegments[ 1 ] === versionSegments[ 1 ]
-			);
-		} )
-	) {
-		return true;
-	}
-}
-
-function semverCompare( a, b ) {
-	const regex = /^(\d+)\.(\d+)\.(\d+)(-rc\.\d+)?$/;
-
-	const aMatches = a.toLowerCase().match( regex );
-	const [ , majorA, minorA, patchA, rcA ] = aMatches;
-
-	const bMatches = b.toLowerCase().match( regex );
-	const [ , majorB, minorB, patchB, rcB ] = bMatches;
-
-	if ( majorA !== majorB ) return majorB - majorA;
-	if ( minorA !== minorB ) return minorB - minorA;
-	if ( patchA !== patchB ) return patchB - patchA;
-
-	if ( ! rcA ) return -1;
-	if ( ! rcB ) return 1;
-
-	return (
-		parseInt( rcB.replace( '-rc.', '' ), 10 ) -
-		parseInt( rcA.replace( '-rc.', '' ), 10 )
-	);
+	return fetch( apiEndpoint )
+		.then( ( res ) => res.json() )
+		.then( ( data ) => parsePluginVersions( data, inputs ) );
 }
 
 // Directly perform this action if it's running in GitHub Actions.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes new JavaScript linting errors that appeared after updating eslint-related dependencies in #185.

```
packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
   12:22  error  'getAPIEndpoint' was used before it was defined       @typescript-eslint/no-use-before-define
   16:22  error  'parsePluginVersions' was used before it was defined  @typescript-eslint/no-use-before-define
   57:8   error  'isRC' was used before it was defined                 @typescript-eslint/no-use-before-define
   57:27  error  'semverCompare' was used before it was defined        @typescript-eslint/no-use-before-define
   59:11  error  'semverCompare' was used before it was defined        @typescript-eslint/no-use-before-define
   67:22  error  'isRC' was used before it was defined                 @typescript-eslint/no-use-before-define
   68:27  error  'isMinorAlreadyAdded' was used before it was defined  @typescript-eslint/no-use-before-define
   82:8   error  'isMinorAlreadyAdded' was used before it was defined  @typescript-eslint/no-use-before-define
  120:27  error  Expected { after 'if' condition                       curly
  121:27  error  Expected { after 'if' condition                       curly
  122:27  error  Expected { after 'if' condition                       curly
  124:15  error  Expected { after 'if' condition                       curly
  125:15  error  Expected { after 'if' condition                       curly
```

### Detailed test instructions:

Check if the `npm run lint:js` can pass
