### PR TITLE
Release version 1.0.1 of the `jsdoc` package

### DIFF
--- a/packages/js/jsdoc/CHANGELOG.md
+++ b/packages/js/jsdoc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-02-26 (1.0.1)
+### Tweaked 🔧
+* Replace shelljs with native Node.js child_process (https://github.com/woocommerce/grow/pull/211)
+* Bump lodash from 4.17.21 to 4.17.23 (https://github.com/woocommerce/grow/pull/197)
+
 ## 2025-11-26 (1.0.0)
 ### New Features 🎉
 * Add `jsdoc` bundle package (https://github.com/woocommerce/grow/pull/10)

--- a/packages/js/jsdoc/package-lock.json
+++ b/packages/js/jsdoc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-grow-jsdoc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-grow-jsdoc",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "jsdoc": "^4.0.2",

--- a/packages/js/jsdoc/package.json
+++ b/packages/js/jsdoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-grow-jsdoc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Grow's JSDoc bundle to document tracking events",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 2026-02-26 (1.0.1)
### Tweaked 🔧
* Replace shelljs with native Node.js child_process (https://github.com/woocommerce/grow/pull/211)
* Bump lodash from 4.17.21 to 4.17.23 (https://github.com/woocommerce/grow/pull/197)