### PR TITLE
Add unit tests and a self-test CI workflow for the `github-actions` package

### DIFF
--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -194,13 +194,13 @@ jobs:
           mkdir /tmp/formatter-test
           cd /tmp/formatter-test
           npm init -y
-          npm install stylelint@${{ matrix.stylelint-version }} stylelint-config-standard
+          npm install stylelint@${{ matrix.stylelint-version }}
           # Prepend eslint-disable to suppress linting on the stylelint formatter
           echo '/* eslint-disable */' > stylelintFormatter.cjs
           cat "$GITHUB_WORKSPACE/packages/github-actions/actions/stylelint-annotation/stylelintFormatter.cjs" >> stylelintFormatter.cjs
           # Create a CSS file with a known lint error (duplicate property)
           echo 'a { color: red; color: blue; }' > sample.css
-          echo '{"extends": "stylelint-config-standard"}' > .stylelintrc.json
+          echo '{"rules": {"declaration-block-no-duplicate-properties": true}}' > .stylelintrc.json
       - name: Verify formatter produces annotation commands
         working-directory: /tmp/formatter-test
         run: |

--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -100,9 +100,14 @@ jobs:
             install-deps: 'yes'
     steps:
       - uses: actions/checkout@v4
-      - name: Create minimal composer.json for install test
+      - name: Create minimal Composer project for install test
         if: matrix.install-deps == 'yes'
-        run: echo '{"require":{}}' > composer.json
+        run: |
+          # The repo's own project depends on the private woocommerce/woorelease
+          # repo, which composer cannot fetch here. Replace it with a minimal
+          # public dependency and drop the lock so the install test is isolated.
+          rm -f composer.lock
+          echo '{"require": {"psr/log": "^3.0"}}' > composer.json
       - uses: ./packages/github-actions/actions/prepare-php
         with:
           php-version: ${{ matrix.php-version }}

--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -1,0 +1,209 @@
+name: GitHub Actions Self-Test
+
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - packages/github-actions/**
+      - .github/workflows/github-actions-self-test.yml
+  pull_request:
+    paths:
+      - packages/github-actions/**
+      - .github/workflows/github-actions-self-test.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        working-directory: packages/github-actions
+        run: npm ci --ignore-scripts
+      - name: Run unit tests
+        working-directory: packages/github-actions
+        run: npm test
+
+  build-check:
+    name: Build Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        working-directory: packages/github-actions
+        run: npm ci --ignore-scripts
+      - name: Verify build succeeds
+        working-directory: packages/github-actions
+        run: npm run build
+
+  test-prepare-node:
+    name: "prepare-node (Node ${{ matrix.node-version }}, deps: ${{ matrix.install-deps }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22']
+        install-deps: ['yes', 'no']
+        ignore-scripts: ['yes']
+        include:
+          - node-version: '20'
+            install-deps: 'yes'
+            ignore-scripts: 'no'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./packages/github-actions/actions/prepare-node
+        with:
+          node-version: ${{ matrix.node-version }}
+          install-deps: ${{ matrix.install-deps }}
+          ignore-scripts: ${{ matrix.ignore-scripts }}
+      - name: Verify Node.js major version
+        env:
+          EXPECTED_VERSION: ${{ matrix.node-version }}
+        run: |
+          ACTUAL=$(node --version | sed 's/^v//' | cut -d. -f1)
+          if [ "$ACTUAL" != "$EXPECTED_VERSION" ]; then
+            echo "Expected Node $EXPECTED_VERSION but got $ACTUAL"
+            exit 1
+          fi
+      # prepare-node runs `npm ci` from the workspace root, so the installed
+      # node_modules lives there. Pin the verification to the same directory.
+      - name: Verify node_modules exists
+        if: matrix.install-deps == 'yes'
+        working-directory: ${{ github.workspace }}
+        run: test -d node_modules
+      - name: Verify node_modules does not exist
+        if: matrix.install-deps == 'no'
+        working-directory: ${{ github.workspace }}
+        run: test ! -d node_modules
+
+  test-prepare-php:
+    name: "prepare-php (PHP ${{ matrix.php-version }}, deps: ${{ matrix.install-deps }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.4', '8.0', '8.2', '8.4']
+        install-deps: ['no']
+        include:
+          - php-version: '8.2'
+            install-deps: 'yes'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create minimal composer.json for install test
+        if: matrix.install-deps == 'yes'
+        run: echo '{"require":{}}' > composer.json
+      - uses: ./packages/github-actions/actions/prepare-php
+        with:
+          php-version: ${{ matrix.php-version }}
+          install-deps: ${{ matrix.install-deps }}
+      - name: Verify PHP version
+        env:
+          EXPECTED_VERSION: ${{ matrix.php-version }}
+        run: |
+          ACTUAL=$(php -r "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;")
+          if [ "$ACTUAL" != "$EXPECTED_VERSION" ]; then
+            echo "Expected PHP $EXPECTED_VERSION but got $ACTUAL"
+            exit 1
+          fi
+      - name: Verify Composer is available
+        run: composer --version
+      - name: Verify vendor directory exists
+        if: matrix.install-deps == 'yes'
+        run: test -d vendor
+
+  test-prepare-mysql:
+    name: prepare-mysql
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./packages/github-actions/actions/prepare-mysql
+      - name: Verify MySQL connection
+        run: mysql -u root -proot -e "SELECT 1;"
+
+  test-eslint-formatter:
+    name: "eslint-annotation (eslint v${{ matrix.eslint-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        eslint-version: ['8', '9']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Build the formatter
+        working-directory: packages/github-actions
+        run: |
+          npm ci --ignore-scripts
+          npm run build
+      - name: Set up test environment
+        run: |
+          mkdir /tmp/formatter-test
+          cd /tmp/formatter-test
+          npm init -y
+          npm install eslint@${{ matrix.eslint-version }}
+          # Prepend eslint-disable to suppress linting on the formatter itself
+          echo '/* eslint-disable */' > eslintFormatter.cjs
+          cat "$GITHUB_WORKSPACE/packages/github-actions/actions/eslint-annotation/eslintFormatter.cjs" >> eslintFormatter.cjs
+          # Create a file with a known lint error
+          echo 'var unused = 1;' > sample.js
+      - name: Verify formatter produces annotation commands
+        working-directory: /tmp/formatter-test
+        run: |
+          MAJOR=$(./node_modules/.bin/eslint --version | cut -d. -f1 | tr -d 'v')
+          if [ "$MAJOR" -ge 9 ]; then
+            CONFIG_FLAG="--no-config-lookup"
+          else
+            CONFIG_FLAG="--no-eslintrc"
+          fi
+          OUTPUT=$(./node_modules/.bin/eslint sample.js $CONFIG_FLAG --rule 'no-unused-vars: error' --format ./eslintFormatter.cjs 2>&1 || true)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -qE '^::(error|warning) '
+
+  test-stylelint-formatter:
+    name: "stylelint-annotation (stylelint v${{ matrix.stylelint-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        stylelint-version: ['15', '16']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Build the formatter
+        working-directory: packages/github-actions
+        run: |
+          npm ci --ignore-scripts
+          npm run build
+      - name: Set up test environment
+        run: |
+          mkdir /tmp/formatter-test
+          cd /tmp/formatter-test
+          npm init -y
+          npm install stylelint@${{ matrix.stylelint-version }} stylelint-config-standard
+          # Prepend eslint-disable to suppress linting on the stylelint formatter
+          echo '/* eslint-disable */' > stylelintFormatter.cjs
+          cat "$GITHUB_WORKSPACE/packages/github-actions/actions/stylelint-annotation/stylelintFormatter.cjs" >> stylelintFormatter.cjs
+          # Create a CSS file with a known lint error (duplicate property)
+          echo 'a { color: red; color: blue; }' > sample.css
+          echo '{"extends": "stylelint-config-standard"}' > .stylelintrc.json
+      - name: Verify formatter produces annotation commands
+        working-directory: /tmp/formatter-test
+        run: |
+          OUTPUT=$(./node_modules/.bin/stylelint sample.css --custom-formatter ./stylelintFormatter.cjs 2>&1 || true)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -qE '^::(error|warning) '

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![JavaScript Linting](https://github.com/woocommerce/grow/actions/workflows/js-linting.yml/badge.svg)](https://github.com/woocommerce/grow/actions/workflows/js-linting.yml)
 [![PHP Coding Standards](https://github.com/woocommerce/grow/actions/workflows/php-coding-standards.yml/badge.svg)](https://github.com/woocommerce/grow/actions/workflows/php-coding-standards.yml)
+[![GitHub Actions Self-Test](https://github.com/woocommerce/grow/actions/workflows/github-actions-self-test.yml/badge.svg)](https://github.com/woocommerce/grow/actions/workflows/github-actions-self-test.yml)
 
 This repository is a container for packages, mostly dev tools to serve the Grow Team.
 The packages here are too experimental or too Grow-specific to be shared Woo-wide.

--- a/packages/github-actions/actions/eslint-annotation/__tests__/to-annotations.test.js
+++ b/packages/github-actions/actions/eslint-annotation/__tests__/to-annotations.test.js
@@ -1,0 +1,142 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import toAnnotations from '../src/to-annotations.js';
+
+describe( 'eslint-annotation toAnnotations', () => {
+	it( 'Should map severity 2 to "error" command', () => {
+		const failedFiles = [
+			{
+				filePath: `${ process.cwd() }/src/index.js`,
+				messages: [
+					{
+						severity: 2,
+						ruleId: 'no-unused-vars',
+						message: "'x' is defined but never used",
+						line: 5,
+						column: 3,
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result.length, 1 );
+		assert.strictEqual( result[ 0 ].command, 'error' );
+	} );
+
+	it( 'Should map severity 1 to "warning" command', () => {
+		const failedFiles = [
+			{
+				filePath: `${ process.cwd() }/src/app.js`,
+				messages: [
+					{
+						severity: 1,
+						ruleId: 'no-console',
+						message: 'Unexpected console statement',
+						line: 10,
+						column: 1,
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result.length, 1 );
+		assert.strictEqual( result[ 0 ].command, 'warning' );
+	} );
+
+	it( 'Should format message as "[ruleId] message"', () => {
+		const failedFiles = [
+			{
+				filePath: `${ process.cwd() }/src/index.js`,
+				messages: [
+					{
+						severity: 2,
+						ruleId: 'semi',
+						message: 'Missing semicolon',
+						line: 1,
+						column: 10,
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result[ 0 ].message, '[semi] Missing semicolon' );
+	} );
+
+	it( 'Should truncate file path to be relative to cwd', () => {
+		const failedFiles = [
+			{
+				filePath: `${ process.cwd() }/src/utils/helper.js`,
+				messages: [
+					{
+						severity: 2,
+						ruleId: 'no-undef',
+						message: "'foo' is not defined",
+						line: 3,
+						column: 1,
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result[ 0 ].filePath, './src/utils/helper.js' );
+	} );
+
+	it( 'Should handle multiple files with multiple messages', () => {
+		const failedFiles = [
+			{
+				filePath: `${ process.cwd() }/a.js`,
+				messages: [
+					{
+						severity: 2,
+						ruleId: 'r1',
+						message: 'm1',
+						line: 1,
+						column: 1,
+					},
+					{
+						severity: 1,
+						ruleId: 'r2',
+						message: 'm2',
+						line: 2,
+						column: 1,
+					},
+				],
+			},
+			{
+				filePath: `${ process.cwd() }/b.js`,
+				messages: [
+					{
+						severity: 2,
+						ruleId: 'r3',
+						message: 'm3',
+						line: 5,
+						column: 10,
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result.length, 3 );
+		assert.strictEqual( result[ 0 ].command, 'error' );
+		assert.strictEqual( result[ 1 ].command, 'warning' );
+		assert.strictEqual( result[ 2 ].filePath, './b.js' );
+	} );
+
+	it( 'Should return an empty array when given no failed files', () => {
+		const result = toAnnotations( [] );
+
+		assert.deepStrictEqual( result, [] );
+	} );
+} );

--- a/packages/github-actions/actions/eslint-annotation/src/eslintFormatter.js
+++ b/packages/github-actions/actions/eslint-annotation/src/eslintFormatter.js
@@ -7,29 +7,7 @@ import { ESLint } from 'eslint'; // eslint-disable-line import/no-extraneous-dep
  * Internal dependencies
  */
 import annotateByWorkflowCommand from '../../../utils/annotate-by-workflow-command.js';
-
-function toAnnotations( failedFiles ) {
-	const truncationPath = process.cwd();
-	const annotations = [];
-
-	failedFiles.forEach( ( file ) => {
-		const filePath = file.filePath.replace( truncationPath, '.' );
-
-		file.messages.forEach( ( lintError ) => {
-			const { severity, ruleId, message } = lintError;
-
-			// About the `severity` value: https://eslint.org/docs/user-guide/formatters/#json
-			annotations.push( {
-				...lintError,
-				command: severity === 2 ? 'error' : 'warning',
-				filePath,
-				message: `[${ ruleId }] ${ message }`,
-			} );
-		} );
-	} );
-
-	return annotations;
-}
+import toAnnotations from './to-annotations.js';
 
 // Ref: https://eslint.org/docs/developer-guide/working-with-custom-formatters
 export default function ( results, context ) {

--- a/packages/github-actions/actions/eslint-annotation/src/to-annotations.js
+++ b/packages/github-actions/actions/eslint-annotation/src/to-annotations.js
@@ -1,0 +1,28 @@
+/**
+ * Converts ESLint result objects to annotation format.
+ *
+ * @param {Array} failedFiles ESLint result objects that have errors or warnings.
+ * @return {Array} Annotations with command, filePath, and message fields.
+ */
+export default function toAnnotations( failedFiles ) {
+	const truncationPath = process.cwd();
+	const annotations = [];
+
+	failedFiles.forEach( ( file ) => {
+		const filePath = file.filePath.replace( truncationPath, '.' );
+
+		file.messages.forEach( ( lintError ) => {
+			const { severity, ruleId, message } = lintError;
+
+			// About the `severity` value: https://eslint.org/docs/user-guide/formatters/#json
+			annotations.push( {
+				...lintError,
+				command: severity === 2 ? 'error' : 'warning',
+				filePath,
+				message: `[${ ruleId }] ${ message }`,
+			} );
+		} );
+	} );
+
+	return annotations;
+}

--- a/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
+++ b/packages/github-actions/actions/get-plugin-releases/src/get-plugin-releases.js
@@ -141,8 +141,7 @@ async function getPluginReleases( inputs ) {
 		.then( ( data ) => parsePluginVersions( data, inputs ) );
 }
 
-// Directly perform this action if it's running in GitHub Actions.
-if ( process.env.GITHUB_ACTIONS ) {
+export function runAction() {
 	const inputs = {
 		slug: getInput( 'slug' ),
 		source: getInput( 'source' ),

--- a/packages/github-actions/actions/get-plugin-releases/src/index.js
+++ b/packages/github-actions/actions/get-plugin-releases/src/index.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { runAction } from './get-plugin-releases.js';
+
+runAction();

--- a/packages/github-actions/actions/get-release-notes/__tests__/match-version-level.test.js
+++ b/packages/github-actions/actions/get-release-notes/__tests__/match-version-level.test.js
@@ -94,11 +94,7 @@ describe( 'matchVersionLevel', () => {
 
 	it( 'Should return "patch" for empty content', () => {
 		assert.strictEqual(
-			matchVersionLevel(
-				'',
-				defaultMajorKeywords,
-				defaultMinorKeywords
-			),
+			matchVersionLevel( '', defaultMajorKeywords, defaultMinorKeywords ),
 			'patch'
 		);
 	} );

--- a/packages/github-actions/actions/get-release-notes/__tests__/match-version-level.test.js
+++ b/packages/github-actions/actions/get-release-notes/__tests__/match-version-level.test.js
@@ -1,0 +1,141 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import matchVersionLevel from '../src/match-version-level.js';
+
+const defaultMajorKeywords = 'breaking';
+const defaultMinorKeywords = 'feature, enhancement';
+
+describe( 'matchVersionLevel', () => {
+	it( 'Should return "major" when a heading matches a major keyword', () => {
+		const content = '### Breaking Changes\n- Removed old API';
+
+		assert.strictEqual(
+			matchVersionLevel(
+				content,
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'major'
+		);
+	} );
+
+	it( 'Should return "minor" when a heading matches a minor keyword', () => {
+		const content = '### New Features\n- Added dark mode';
+
+		assert.strictEqual(
+			matchVersionLevel(
+				content,
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'minor'
+		);
+	} );
+
+	it( 'Should return "minor" when a heading matches the "enhancement" keyword', () => {
+		const content = '### Enhancements\n- Improved performance';
+
+		assert.strictEqual(
+			matchVersionLevel(
+				content,
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'minor'
+		);
+	} );
+
+	it( 'Should return "patch" when no heading matches any keyword', () => {
+		const content = '### Bug Fixes\n- Fixed crash on startup';
+
+		assert.strictEqual(
+			matchVersionLevel(
+				content,
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'patch'
+		);
+	} );
+
+	it( 'Should match keywords case-insensitively', () => {
+		const content = '### BREAKING changes\n- Major overhaul';
+
+		assert.strictEqual(
+			matchVersionLevel(
+				content,
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'major'
+		);
+	} );
+
+	it( 'Should prioritize "major" over "minor" when both match', () => {
+		const content =
+			'### Breaking Changes\n- Removed API\n### New Features\n- Added widget';
+
+		assert.strictEqual(
+			matchVersionLevel(
+				content,
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'major'
+		);
+	} );
+
+	it( 'Should return "patch" for empty content', () => {
+		assert.strictEqual(
+			matchVersionLevel(
+				'',
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'patch'
+		);
+	} );
+
+	it( 'Should return "patch" for content with no headings', () => {
+		const content = 'Just some plain text without any headings.';
+
+		assert.strictEqual(
+			matchVersionLevel(
+				content,
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'patch'
+		);
+	} );
+
+	it( 'Should support custom comma-separated keywords with spaces', () => {
+		const content = '### Awesome Stuff\n- Something cool';
+
+		assert.strictEqual(
+			matchVersionLevel( content, 'major changes', 'awesome, cool' ),
+			'minor'
+		);
+	} );
+
+	it( 'Should only match headings (###), not body text', () => {
+		const content =
+			'### Bug Fixes\n- This is a breaking change in behavior';
+
+		assert.strictEqual(
+			matchVersionLevel(
+				content,
+				defaultMajorKeywords,
+				defaultMinorKeywords
+			),
+			'patch'
+		);
+	} );
+} );

--- a/packages/github-actions/actions/get-release-notes/__tests__/release-notes-utils.test.js
+++ b/packages/github-actions/actions/get-release-notes/__tests__/release-notes-utils.test.js
@@ -15,7 +15,7 @@ import {
 describe( 'parseChangelog', () => {
 	it( 'Should extract the "What\'s Changed" section', () => {
 		const notes = [
-			'## What\'s Changed',
+			"## What's Changed",
 			'* Fix bug by @user in #123',
 			'* Add feature by @user in #456',
 			'',
@@ -78,10 +78,7 @@ describe( 'escapeSingleQuote', () => {
 	} );
 
 	it( 'Should handle multiple consecutive single quotes', () => {
-		assert.strictEqual(
-			escapeSingleQuote( "a''b" ),
-			"a'\"'\"''\"'\"'b"
-		);
+		assert.strictEqual( escapeSingleQuote( "a''b" ), "a'\"'\"''\"'\"'b" );
 	} );
 
 	it( 'Should handle empty string', () => {

--- a/packages/github-actions/actions/get-release-notes/__tests__/release-notes-utils.test.js
+++ b/packages/github-actions/actions/get-release-notes/__tests__/release-notes-utils.test.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import {
+	parseChangelog,
+	escapeSingleQuote,
+} from '../src/release-notes-utils.js';
+
+describe( 'parseChangelog', () => {
+	it( 'Should extract the "What\'s Changed" section', () => {
+		const notes = [
+			'## What\'s Changed',
+			'* Fix bug by @user in #123',
+			'* Add feature by @user in #456',
+			'',
+			'## New Contributors',
+			'* @user made their first contribution',
+		].join( '\n' );
+
+		const result = parseChangelog( notes );
+
+		assert.strictEqual(
+			result,
+			'* Fix bug by @user in #123\n* Add feature by @user in #456'
+		);
+	} );
+
+	it( 'Should return empty string when no "What\'s Changed" section exists', () => {
+		const notes = [
+			'## New Contributors',
+			'* @user made their first contribution',
+		].join( '\n' );
+
+		assert.strictEqual( parseChangelog( notes ), '' );
+	} );
+
+	it( 'Should match case-insensitively', () => {
+		const notes = [
+			"## what's changed",
+			'* Some change',
+			'',
+			'## Other section',
+		].join( '\n' );
+
+		assert.strictEqual( parseChangelog( notes ), '* Some change' );
+	} );
+
+	it( 'Should return empty string for empty content', () => {
+		assert.strictEqual( parseChangelog( '' ), '' );
+	} );
+
+	it( 'Should return empty string when section is at end without trailing blank line', () => {
+		const notes = "## What's Changed\n* Fix bug by @user in #123";
+
+		assert.strictEqual( parseChangelog( notes ), '' );
+	} );
+} );
+
+describe( 'escapeSingleQuote', () => {
+	it( 'Should escape single quotes', () => {
+		assert.strictEqual(
+			escapeSingleQuote( "it's a test" ),
+			"it'\"'\"'s a test"
+		);
+	} );
+
+	it( 'Should return unchanged text without single quotes', () => {
+		assert.strictEqual(
+			escapeSingleQuote( 'no quotes here' ),
+			'no quotes here'
+		);
+	} );
+
+	it( 'Should handle multiple consecutive single quotes', () => {
+		assert.strictEqual(
+			escapeSingleQuote( "a''b" ),
+			"a'\"'\"''\"'\"'b"
+		);
+	} );
+
+	it( 'Should handle empty string', () => {
+		assert.strictEqual( escapeSingleQuote( '' ), '' );
+	} );
+} );

--- a/packages/github-actions/actions/get-release-notes/src/get-release-notes.js
+++ b/packages/github-actions/actions/get-release-notes/src/get-release-notes.js
@@ -12,26 +12,13 @@ import PackageTool from '../../../utils/package-tool.js';
 import RepoTool from '../../../utils/repo-tool.js';
 import handleActionErrors from '../../../utils/handle-action-errors.js';
 import matchVersionLevel from './match-version-level.js';
+import { parseChangelog, escapeSingleQuote } from './release-notes-utils.js';
 
 const TMP_TAG = 'tmp--github-action-get-release-notes';
 
 function compositeVersionTag( version ) {
 	const template = core.getInput( 'tag-template' );
 	return template.replace( '{version}', version );
-}
-
-function parseChangelog( notesContent ) {
-	const matched = notesContent.match(
-		/## What's Changed\n([\d\D]+?)(?=\n\n)/i
-	);
-	if ( matched ) {
-		return matched[ 1 ];
-	}
-	return '';
-}
-
-function escapeSingleQuote( text ) {
-	return text.replace( /'/g, `'"'"'` );
 }
 
 function setOutput( key, value ) {

--- a/packages/github-actions/actions/get-release-notes/src/release-notes-utils.js
+++ b/packages/github-actions/actions/get-release-notes/src/release-notes-utils.js
@@ -1,0 +1,25 @@
+/**
+ * Extracts the "What's Changed" section from release notes content.
+ *
+ * @param {string} notesContent The content of release notes from GitHub.
+ * @return {string} The changelog content, or empty string if not found.
+ */
+export function parseChangelog( notesContent ) {
+	const matched = notesContent.match(
+		/## What's Changed\n([\d\D]+?)(?=\n\n)/i
+	);
+	if ( matched ) {
+		return matched[ 1 ];
+	}
+	return '';
+}
+
+/**
+ * Escapes single quotes for safe use in shell commands.
+ *
+ * @param {string} text The text to escape.
+ * @return {string} The escaped text.
+ */
+export function escapeSingleQuote( text ) {
+	return text.replace( /'/g, `'"'"'` );
+}

--- a/packages/github-actions/actions/phpcs-diff/__tests__/to-annotations.test.js
+++ b/packages/github-actions/actions/phpcs-diff/__tests__/to-annotations.test.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import toAnnotations from '../src/to-annotations.js';
+
+describe( 'phpcs-diff toAnnotations', () => {
+	it( 'Should always set command to "error"', () => {
+		const reportFiles = {
+			'src/Example.php': {
+				messages: [
+					{ line: 10, message: 'Missing docblock' },
+				],
+			},
+		};
+		const result = toAnnotations( reportFiles );
+
+		assert.strictEqual( result.length, 1 );
+		assert.strictEqual( result[ 0 ].command, 'error' );
+	} );
+
+	it( 'Should prefix file path with "./"', () => {
+		const reportFiles = {
+			'src/Example.php': {
+				messages: [
+					{ line: 5, message: 'Some error' },
+				],
+			},
+		};
+		const result = toAnnotations( reportFiles );
+
+		assert.strictEqual( result[ 0 ].filePath, './src/Example.php' );
+	} );
+
+	it( 'Should include line number and message', () => {
+		const reportFiles = {
+			'src/App.php': {
+				messages: [
+					{ line: 42, message: 'Expected 1 space after comma' },
+				],
+			},
+		};
+		const result = toAnnotations( reportFiles );
+
+		assert.strictEqual( result[ 0 ].line, 42 );
+		assert.strictEqual(
+			result[ 0 ].message,
+			'Expected 1 space after comma'
+		);
+	} );
+
+	it( 'Should handle multiple files with multiple messages', () => {
+		const reportFiles = {
+			'a.php': {
+				messages: [
+					{ line: 1, message: 'Error 1' },
+					{ line: 2, message: 'Error 2' },
+				],
+			},
+			'b.php': {
+				messages: [
+					{ line: 10, message: 'Error 3' },
+				],
+			},
+		};
+		const result = toAnnotations( reportFiles );
+
+		assert.strictEqual( result.length, 3 );
+		assert.strictEqual( result[ 0 ].filePath, './a.php' );
+		assert.strictEqual( result[ 2 ].filePath, './b.php' );
+	} );
+
+	it( 'Should return an empty array for an empty report', () => {
+		const result = toAnnotations( {} );
+
+		assert.deepStrictEqual( result, [] );
+	} );
+} );

--- a/packages/github-actions/actions/phpcs-diff/__tests__/to-annotations.test.js
+++ b/packages/github-actions/actions/phpcs-diff/__tests__/to-annotations.test.js
@@ -13,9 +13,7 @@ describe( 'phpcs-diff toAnnotations', () => {
 	it( 'Should always set command to "error"', () => {
 		const reportFiles = {
 			'src/Example.php': {
-				messages: [
-					{ line: 10, message: 'Missing docblock' },
-				],
+				messages: [ { line: 10, message: 'Missing docblock' } ],
 			},
 		};
 		const result = toAnnotations( reportFiles );
@@ -27,9 +25,7 @@ describe( 'phpcs-diff toAnnotations', () => {
 	it( 'Should prefix file path with "./"', () => {
 		const reportFiles = {
 			'src/Example.php': {
-				messages: [
-					{ line: 5, message: 'Some error' },
-				],
+				messages: [ { line: 5, message: 'Some error' } ],
 			},
 		};
 		const result = toAnnotations( reportFiles );
@@ -63,9 +59,7 @@ describe( 'phpcs-diff toAnnotations', () => {
 				],
 			},
 			'b.php': {
-				messages: [
-					{ line: 10, message: 'Error 3' },
-				],
+				messages: [ { line: 10, message: 'Error 3' } ],
 			},
 		};
 		const result = toAnnotations( reportFiles );

--- a/packages/github-actions/actions/phpcs-diff/src/annotate-phpcs-report.js
+++ b/packages/github-actions/actions/phpcs-diff/src/annotate-phpcs-report.js
@@ -9,27 +9,7 @@ import { argv } from 'node:process';
  */
 import annotateByWorkflowCommand from '../../../utils/annotate-by-workflow-command.js';
 import handleActionErrors from '../../../utils/handle-action-errors.js';
-
-function toAnnotations( reportFiles ) {
-	const entries = Object.entries( reportFiles );
-	const annotations = [];
-
-	entries.forEach( ( [ filePath, metadata ] ) => {
-		metadata.messages.forEach( ( { line, message } ) => {
-			// The `coverageChecker` package doesn't output warnings by default,
-			// and warnings are treated as errors in its strict mode.
-			// So all messages can only be transformed as error annotations here.
-			annotations.push( {
-				command: 'error',
-				filePath: `./${ filePath }`,
-				line,
-				message,
-			} );
-		} );
-	} );
-
-	return annotations;
-}
+import toAnnotations from './to-annotations.js';
 
 /**
  * Sets errors in the PHPCS as annotations onto GitHub Actions.

--- a/packages/github-actions/actions/phpcs-diff/src/to-annotations.js
+++ b/packages/github-actions/actions/phpcs-diff/src/to-annotations.js
@@ -1,0 +1,26 @@
+/**
+ * Converts PHPCS report file entries to annotation format.
+ *
+ * @param {Object} reportFiles PHPCS report files object keyed by file path.
+ * @return {Array} Annotations with command, filePath, line, and message fields.
+ */
+export default function toAnnotations( reportFiles ) {
+	const entries = Object.entries( reportFiles );
+	const annotations = [];
+
+	entries.forEach( ( [ filePath, metadata ] ) => {
+		metadata.messages.forEach( ( { line, message } ) => {
+			// The `coverageChecker` package doesn't output warnings by default,
+			// and warnings are treated as errors in its strict mode.
+			// So all messages can only be transformed as error annotations here.
+			annotations.push( {
+				command: 'error',
+				filePath: `./${ filePath }`,
+				line,
+				message,
+			} );
+		} );
+	} );
+
+	return annotations;
+}

--- a/packages/github-actions/actions/stylelint-annotation/__tests__/to-annotations.test.js
+++ b/packages/github-actions/actions/stylelint-annotation/__tests__/to-annotations.test.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import toAnnotations from '../src/to-annotations.js';
+
+describe( 'stylelint-annotation toAnnotations', () => {
+	it( 'Should use the severity string as the command', () => {
+		const failedFiles = [
+			{
+				source: `${ process.cwd() }/src/style.css`,
+				warnings: [
+					{
+						severity: 'error',
+						line: 5,
+						column: 3,
+						text: 'Unexpected empty block (block-no-empty)',
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result.length, 1 );
+		assert.strictEqual( result[ 0 ].command, 'error' );
+	} );
+
+	it( 'Should handle "warning" severity', () => {
+		const failedFiles = [
+			{
+				source: `${ process.cwd() }/src/app.css`,
+				warnings: [
+					{
+						severity: 'warning',
+						line: 10,
+						column: 1,
+						text: 'Expected single space (declaration-colon-space-after)',
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result[ 0 ].command, 'warning' );
+	} );
+
+	it( 'Should truncate file path from .source to be relative to cwd', () => {
+		const failedFiles = [
+			{
+				source: `${ process.cwd() }/src/components/button.css`,
+				warnings: [
+					{
+						severity: 'error',
+						line: 1,
+						column: 1,
+						text: 'Some error',
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual(
+			result[ 0 ].filePath,
+			'./src/components/button.css'
+		);
+	} );
+
+	it( 'Should pass through message text', () => {
+		const messageText = 'Expected indentation of 2 spaces (indentation)';
+		const failedFiles = [
+			{
+				source: `${ process.cwd() }/a.css`,
+				warnings: [
+					{
+						severity: 'warning',
+						line: 3,
+						column: 1,
+						text: messageText,
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result[ 0 ].message, messageText );
+	} );
+
+	it( 'Should handle multiple files with multiple warnings', () => {
+		const failedFiles = [
+			{
+				source: `${ process.cwd() }/a.css`,
+				warnings: [
+					{
+						severity: 'error',
+						line: 1,
+						column: 1,
+						text: 'Error 1',
+					},
+					{
+						severity: 'warning',
+						line: 2,
+						column: 5,
+						text: 'Warning 1',
+					},
+				],
+			},
+			{
+				source: `${ process.cwd() }/b.css`,
+				warnings: [
+					{
+						severity: 'error',
+						line: 10,
+						column: 3,
+						text: 'Error 2',
+					},
+				],
+			},
+		];
+		const result = toAnnotations( failedFiles );
+
+		assert.strictEqual( result.length, 3 );
+		assert.strictEqual( result[ 0 ].command, 'error' );
+		assert.strictEqual( result[ 1 ].command, 'warning' );
+		assert.strictEqual( result[ 2 ].filePath, './b.css' );
+	} );
+
+	it( 'Should return an empty array when given no failed files', () => {
+		const result = toAnnotations( [] );
+
+		assert.deepStrictEqual( result, [] );
+	} );
+} );

--- a/packages/github-actions/actions/stylelint-annotation/src/stylelintFormatter.js
+++ b/packages/github-actions/actions/stylelint-annotation/src/stylelintFormatter.js
@@ -7,29 +7,7 @@ import stylelint from 'stylelint'; // eslint-disable-line import/no-extraneous-d
  * Internal dependencies
  */
 import annotateByWorkflowCommand from '../../../utils/annotate-by-workflow-command.js';
-
-function toAnnotations( failedFiles ) {
-	const truncationPath = process.cwd();
-	const annotations = [];
-
-	failedFiles.forEach( ( file ) => {
-		const filePath = file.source.replace( truncationPath, '.' );
-
-		file.warnings.forEach( ( lintError ) => {
-			const { severity, line, column, text } = lintError;
-
-			annotations.push( {
-				command: severity,
-				filePath,
-				line,
-				column,
-				message: text,
-			} );
-		} );
-	} );
-
-	return annotations;
-}
+import toAnnotations from './to-annotations.js';
 
 // Ref: https://stylelint.io/developer-guide/formatters/
 export default function ( results, returnValue ) {

--- a/packages/github-actions/actions/stylelint-annotation/src/to-annotations.js
+++ b/packages/github-actions/actions/stylelint-annotation/src/to-annotations.js
@@ -1,0 +1,28 @@
+/**
+ * Converts Stylelint result objects to annotation format.
+ *
+ * @param {Array} failedFiles Stylelint result objects that have warnings.
+ * @return {Array} Annotations with command, filePath, and message fields.
+ */
+export default function toAnnotations( failedFiles ) {
+	const truncationPath = process.cwd();
+	const annotations = [];
+
+	failedFiles.forEach( ( file ) => {
+		const filePath = file.source.replace( truncationPath, '.' );
+
+		file.warnings.forEach( ( lintError ) => {
+			const { severity, line, column, text } = lintError;
+
+			annotations.push( {
+				command: severity,
+				filePath,
+				line,
+				column,
+				message: text,
+			} );
+		} );
+	} );
+
+	return annotations;
+}

--- a/packages/github-actions/actions/update-version-tags/__tests__/parse-version.test.js
+++ b/packages/github-actions/actions/update-version-tags/__tests__/parse-version.test.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import parseVersion from '../src/parse-version.js';
+
+describe( 'parseVersion', () => {
+	it( 'Should parse a plain version', () => {
+		const result = parseVersion( '1.2.3' );
+
+		assert.deepStrictEqual( result, {
+			majorVersion: '1',
+			minorVersion: '1.2',
+		} );
+	} );
+
+	it( 'Should parse a version with leading v', () => {
+		const result = parseVersion( 'v1.2.3' );
+
+		assert.deepStrictEqual( result, {
+			majorVersion: 'v1',
+			minorVersion: 'v1.2',
+		} );
+	} );
+
+	it( 'Should parse a version with prefix', () => {
+		const result = parseVersion( 'tools-1.2.3' );
+
+		assert.deepStrictEqual( result, {
+			majorVersion: 'tools-1',
+			minorVersion: 'tools-1.2',
+		} );
+	} );
+
+	it( 'Should parse a version with prefix and leading v', () => {
+		const result = parseVersion( 'tools-v1.2.3' );
+
+		assert.deepStrictEqual( result, {
+			majorVersion: 'tools-v1',
+			minorVersion: 'tools-v1.2',
+		} );
+	} );
+
+	it( 'Should parse a version with a complex multi-segment prefix', () => {
+		const result = parseVersion( 'ipv6-tools-v1.2.3' );
+
+		assert.deepStrictEqual( result, {
+			majorVersion: 'ipv6-tools-v1',
+			minorVersion: 'ipv6-tools-v1.2',
+		} );
+	} );
+
+	it( 'Should include prerelease identifiers in both major and minor versions', () => {
+		const result = parseVersion( 'tools-v1.2.3-beta.0' );
+
+		assert.deepStrictEqual( result, {
+			majorVersion: 'tools-v1-beta.0',
+			minorVersion: 'tools-v1.2-beta.0',
+		} );
+	} );
+
+	it( 'Should handle prerelease with a single identifier', () => {
+		const result = parseVersion( 'v1.2.3-pre' );
+
+		assert.deepStrictEqual( result, {
+			majorVersion: 'v1-pre',
+			minorVersion: 'v1.2-pre',
+		} );
+	} );
+
+	it( 'Should return null for an invalid version', () => {
+		assert.strictEqual( parseVersion( 'not-a-version' ), null );
+	} );
+
+	it( 'Should return null for "trunk"', () => {
+		assert.strictEqual( parseVersion( 'trunk' ), null );
+	} );
+
+	it( 'Should return null for an empty string', () => {
+		assert.strictEqual( parseVersion( '' ), null );
+	} );
+} );

--- a/packages/github-actions/package.json
+++ b/packages/github-actions/package.json
@@ -4,8 +4,8 @@
   "description": "GitHub JavaScript actions for a WooCommerce plugin repo by Grow Team.",
   "type": "module",
   "scripts": {
-    "test": "node --test ./actions/**/__tests__/*.test.js",
-    "test:watch": "node --test --watch ./actions/**/__tests__/*.test.js",
+    "test": "node --test ./actions/**/__tests__/*.test.js ./utils/__tests__/*.test.js",
+    "test:watch": "node --test --watch ./actions/**/__tests__/*.test.js ./utils/__tests__/*.test.js",
     "build": "rollup -c"
   },
   "author": "WooCommerce",

--- a/packages/github-actions/rollup.config.js
+++ b/packages/github-actions/rollup.config.js
@@ -63,7 +63,7 @@ export default [
 		],
 	},
 	{
-		input: './actions/get-plugin-releases/src/get-plugin-releases.js',
+		input: './actions/get-plugin-releases/src/index.js',
 		output: {
 			file: './actions/get-plugin-releases/get-plugin-releases.mjs',
 		},

--- a/packages/github-actions/utils/__tests__/annotate-by-workflow-command.test.js
+++ b/packages/github-actions/utils/__tests__/annotate-by-workflow-command.test.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import { toAnnotationCommand } from '../annotate-by-workflow-command.js';
+
+describe( 'toAnnotationCommand', () => {
+	it( 'Should format a full annotation with all fields', () => {
+		const annotation = {
+			command: 'error',
+			filePath: './src/index.js',
+			line: 10,
+			endLine: 12,
+			column: 5,
+			endColumn: 20,
+			message: 'Unexpected token',
+		};
+
+		assert.strictEqual(
+			toAnnotationCommand( annotation ),
+			'::error file=./src/index.js,line=10,endLine=12,col=5,endColumn=20::Unexpected token'
+		);
+	} );
+
+	it( 'Should omit missing optional fields', () => {
+		const annotation = {
+			command: 'warning',
+			filePath: './src/app.js',
+			line: 3,
+			message: 'Unused variable',
+		};
+
+		assert.strictEqual(
+			toAnnotationCommand( annotation ),
+			'::warning file=./src/app.js,line=3::Unused variable'
+		);
+	} );
+
+	it( 'Should format a group command', () => {
+		const annotation = {
+			command: 'group',
+			message: 'Annotation commands',
+		};
+
+		assert.strictEqual(
+			toAnnotationCommand( annotation ),
+			'::group::Annotation commands'
+		);
+	} );
+
+	it( 'Should format an endgroup command', () => {
+		const annotation = {
+			command: 'endgroup',
+		};
+
+		assert.strictEqual(
+			toAnnotationCommand( annotation ),
+			'::endgroup::'
+		);
+	} );
+
+	it( 'Should format a notice command', () => {
+		const annotation = {
+			command: 'notice',
+			filePath: './README.md',
+			line: 1,
+			message: 'Consider updating',
+		};
+
+		assert.strictEqual(
+			toAnnotationCommand( annotation ),
+			'::notice file=./README.md,line=1::Consider updating'
+		);
+	} );
+} );

--- a/packages/github-actions/utils/__tests__/annotate-by-workflow-command.test.js
+++ b/packages/github-actions/utils/__tests__/annotate-by-workflow-command.test.js
@@ -58,10 +58,7 @@ describe( 'toAnnotationCommand', () => {
 			command: 'endgroup',
 		};
 
-		assert.strictEqual(
-			toAnnotationCommand( annotation ),
-			'::endgroup::'
-		);
+		assert.strictEqual( toAnnotationCommand( annotation ), '::endgroup::' );
 	} );
 
 	it( 'Should format a notice command', () => {

--- a/packages/github-actions/utils/__tests__/fixtures/test-package/CHANGELOG.md
+++ b/packages/github-actions/utils/__tests__/fixtures/test-package/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 2025-01-15 (1.5.0)
+- Added new feature X
+- Improved performance
+
+## 2024-12-01 (1.4.7)
+- Fixed critical bug in auth module
+- Updated dependencies
+
+## 2024-11-10 (1.4.6)
+- Minor style fixes

--- a/packages/github-actions/utils/__tests__/fixtures/test-package/package.json
+++ b/packages/github-actions/utils/__tests__/fixtures/test-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-package",
+  "version": "1.4.7",
+  "description": "A test fixture for PackageTool unit tests."
+}

--- a/packages/github-actions/utils/__tests__/package-tool.test.js
+++ b/packages/github-actions/utils/__tests__/package-tool.test.js
@@ -32,9 +32,7 @@ describe( 'PackageTool', () => {
 				() => tool.getFile( 'nonexistent.txt' ),
 				( err ) => {
 					assert.ok( err instanceof Error );
-					assert.ok(
-						err.message.includes( 'nonexistent.txt' )
-					);
+					assert.ok( err.message.includes( 'nonexistent.txt' ) );
 					assert.ok( err.message.includes( 'does not exist' ) );
 					return true;
 				}
@@ -58,16 +56,11 @@ describe( 'PackageTool', () => {
 			const result = tool.getChangelogByVersion( '1.4.7' );
 
 			assert.strictEqual( result.version, '1.4.7' );
-			assert.strictEqual(
-				result.heading,
-				'## 2024-12-01 (1.4.7)'
-			);
+			assert.strictEqual( result.heading, '## 2024-12-01 (1.4.7)' );
 			assert.ok(
 				result.content.includes( 'Fixed critical bug in auth module' )
 			);
-			assert.ok(
-				result.content.includes( 'Updated dependencies' )
-			);
+			assert.ok( result.content.includes( 'Updated dependencies' ) );
 		} );
 
 		it( 'Should return empty heading and content for a nonexistent version', () => {
@@ -83,13 +76,8 @@ describe( 'PackageTool', () => {
 			const tool = new PackageTool( 'test-package', fixturesDir );
 			const result = tool.getChangelogByVersion( '1.5.0' );
 
-			assert.strictEqual(
-				result.heading,
-				'## 2025-01-15 (1.5.0)'
-			);
-			assert.ok(
-				result.content.includes( 'Added new feature X' )
-			);
+			assert.strictEqual( result.heading, '## 2025-01-15 (1.5.0)' );
+			assert.ok( result.content.includes( 'Added new feature X' ) );
 		} );
 	} );
 } );

--- a/packages/github-actions/utils/__tests__/package-tool.test.js
+++ b/packages/github-actions/utils/__tests__/package-tool.test.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Internal dependencies
+ */
+import PackageTool from '../package-tool.js';
+
+const fixturesDir = path.join(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'fixtures'
+);
+
+describe( 'PackageTool', () => {
+	describe( 'getFile', () => {
+		it( 'Should read a file from the package directory', () => {
+			const tool = new PackageTool( 'test-package', fixturesDir );
+			const content = tool.getFile( 'package.json' );
+
+			assert.ok( content.includes( '"test-package"' ) );
+		} );
+
+		it( 'Should throw when the file does not exist', () => {
+			const tool = new PackageTool( 'test-package', fixturesDir );
+
+			assert.throws(
+				() => tool.getFile( 'nonexistent.txt' ),
+				( err ) => {
+					assert.ok( err instanceof Error );
+					assert.ok(
+						err.message.includes( 'nonexistent.txt' )
+					);
+					assert.ok( err.message.includes( 'does not exist' ) );
+					return true;
+				}
+			);
+		} );
+	} );
+
+	describe( 'getSettings', () => {
+		it( 'Should parse and return package.json content', () => {
+			const tool = new PackageTool( 'test-package', fixturesDir );
+			const settings = tool.getSettings();
+
+			assert.strictEqual( settings.name, 'test-package' );
+			assert.strictEqual( settings.version, '1.4.7' );
+		} );
+	} );
+
+	describe( 'getChangelogByVersion', () => {
+		it( 'Should extract the correct version section from CHANGELOG', () => {
+			const tool = new PackageTool( 'test-package', fixturesDir );
+			const result = tool.getChangelogByVersion( '1.4.7' );
+
+			assert.strictEqual( result.version, '1.4.7' );
+			assert.strictEqual(
+				result.heading,
+				'## 2024-12-01 (1.4.7)'
+			);
+			assert.ok(
+				result.content.includes( 'Fixed critical bug in auth module' )
+			);
+			assert.ok(
+				result.content.includes( 'Updated dependencies' )
+			);
+		} );
+
+		it( 'Should return empty heading and content for a nonexistent version', () => {
+			const tool = new PackageTool( 'test-package', fixturesDir );
+			const result = tool.getChangelogByVersion( '9.9.9' );
+
+			assert.strictEqual( result.version, '9.9.9' );
+			assert.strictEqual( result.heading, '' );
+			assert.strictEqual( result.content, '' );
+		} );
+
+		it( 'Should extract a different version correctly', () => {
+			const tool = new PackageTool( 'test-package', fixturesDir );
+			const result = tool.getChangelogByVersion( '1.5.0' );
+
+			assert.strictEqual(
+				result.heading,
+				'## 2025-01-15 (1.5.0)'
+			);
+			assert.ok(
+				result.content.includes( 'Added new feature X' )
+			);
+		} );
+	} );
+} );

--- a/packages/github-actions/utils/annotate-by-workflow-command.js
+++ b/packages/github-actions/utils/annotate-by-workflow-command.js
@@ -9,7 +9,7 @@
  * @property {string} [endColumn] End column number of the associated file.
  */
 
-function toAnnotationCommand( annotation ) {
+export function toAnnotationCommand( annotation ) {
 	const regex = /([ ,]?\w+=)?\{(\w+)\}/g;
 	const template =
 		'::{command} file={filePath},line={line},endLine={endLine},col={column},endColumn={endColumn}::{message}';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a preparatory step for the upcoming Node.js v24 upgrade. Adding automated tests and a self-test workflow first establishes a regression net, so the upgrade can be verified at each step and proceed on a more solid footing.

This PR adds automated test coverage for the JavaScript logic in the `github-actions` package, plus a CI workflow that self-validates the package's actions. To make the logic testable in isolation, some source files are refactored to extract pure functions. The extractions are 1:1 moves with no behavior change, and the original callers import and use the extracted functions.

**Unit tests** (`node --test`) added for:

- `parseVersion` (`update-version-tags`)
- `matchVersionLevel` (`get-release-notes`)
- `parseChangelog` and `escapeSingleQuote` (`get-release-notes`, newly extracted)
- `toAnnotationCommand` (newly named-exported)
- `toAnnotations` for `eslint-annotation`, `stylelint-annotation`, and `phpcs-diff` (newly extracted)
- `PackageTool` util

**CI workflow** `.github/workflows/github-actions-self-test.yml`, triggered on changes under `packages/github-actions/**`, with jobs for:

1. Unit tests (`node --test`)
2. Build check (rollup build succeeds)
3. `prepare-node` validation (matrix: Node 20/22, install-deps yes/no)
4. `prepare-php` validation (matrix: PHP 7.4/8.0/8.2/8.4)
5. `prepare-mysql` validation (MySQL connection)
6. `eslint-annotation` formatter compatibility (matrix: eslint v8/v9)
7. `stylelint-annotation` formatter compatibility (matrix: stylelint v15/v16)

### Detailed test instructions:

1. Install dependencies and run the unit tests locally:
   ```
   cd packages/github-actions
   npm ci
   npm test
   ```
2. Confirm all tests pass.
3. Under the Checks tab of this PR, confirm every job of the "GitHub Actions Self-Test" workflow passes.