### PR TITLE
Improve release build error handling and auto-merge the release PR

### DIFF
--- a/.github/scripts/create-pr-for-release.mjs
+++ b/.github/scripts/create-pr-for-release.mjs
@@ -25,7 +25,7 @@ export default async ( {
 - [ ] The changelog is correct.
 ## Next steps
 1. Approve this PR to allow [the next workflow creates a new release](${ workflowBaseUrl }/${ createReleaseWorkflow }).
-1. Merge this PR after the new release is successfully created and [the version tags are updated](${ workflowBaseUrl }/${ releaseWorkflow }).
+1. After the new release is successfully created, [the release workflow](${ workflowBaseUrl }/${ releaseWorkflow }) will update the version tags and merge this PR automatically.
 ---
 ${ heading }
 ${ content }`;

--- a/.github/scripts/github-actions-create-and-commit-build.sh
+++ b/.github/scripts/github-actions-create-and-commit-build.sh
@@ -9,6 +9,16 @@ REPO_URL=$1
 TAG_NAME=$2
 SOURCE_SHA=$(git rev-parse HEAD)
 
+TMP_BRANCH="tmp-gha-release-build"
+TMP_BRANCH_PUSHED=false
+
+cleanup() {
+  if [ "$TMP_BRANCH_PUSHED" = true ]; then
+    git push -d origin "$TMP_BRANCH" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
 # To build all actions:
 
 pushd ./packages/github-actions
@@ -64,7 +74,9 @@ git add README.md
 ## 7. Complete the build for release or test.
 git commit -q --amend -C HEAD
 
-# The temporary `tmp-gha-release-build` branch is only for pushing to the remote repo.
+# The temporary branch is only for pushing to the remote repo.
 # Tagging it with a version tag will be proceeded with a separate step.
-git push origin HEAD:refs/heads/tmp-gha-release-build
-git push -d origin tmp-gha-release-build
+git push origin "HEAD:refs/heads/$TMP_BRANCH"
+TMP_BRANCH_PUSHED=true
+git push -d origin "$TMP_BRANCH"
+TMP_BRANCH_PUSHED=false

--- a/.github/scripts/github-actions-create-and-commit-build.sh
+++ b/.github/scripts/github-actions-create-and-commit-build.sh
@@ -78,5 +78,9 @@ git commit -q --amend -C HEAD
 # Tagging it with a version tag will be proceeded with a separate step.
 git push origin "HEAD:refs/heads/$TMP_BRANCH"
 TMP_BRANCH_PUSHED=true
-git push -d origin "$TMP_BRANCH"
-TMP_BRANCH_PUSHED=false
+
+# Deleting the temporary branch is cleanup, so a failure here should not fail an
+# otherwise successful release. Leave it best-effort and let the EXIT trap retry.
+if git push -d origin "$TMP_BRANCH"; then
+  TMP_BRANCH_PUSHED=false
+fi

--- a/.github/scripts/github-actions-create-and-commit-build.sh
+++ b/.github/scripts/github-actions-create-and-commit-build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # The value of TAG_NAME and the content composited from it are described in terms of
 # the official release build. When creating a test build, a branch name is passed in,

--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -108,3 +108,21 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ steps.commit-build.outputs.sha }}
           release: ${{ needs.Setup.outputs.release }}
+
+  MergeReleasePR:
+    name: Merge Release PR
+    if: ${{ github.event_name == 'workflow_run' }}
+    needs: UpdateTags
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Merge the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.workflow_run.head_branch }}" \
+            --repo "${{ github.repository }}" \
+            --merge \
+            --delete-branch

--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -165,13 +165,12 @@ Branch off from the old version, set the merge base for fixing PR to be the same
 1. :technologist: If it's all good, approve the release PR to proceed with the next workflow.
 1. :octocat: Once the release PR is approved, a workflow will create a new release with a new version tag.
    - Workflow [GitHub Actions - Create Release](https://github.com/woocommerce/grow/actions/workflows/github-actions-create-release.yml)
-1. :octocat: After publishing the new release, a workflow will continue to create and commit the release build. And then update the references of the corresponding major and minor version tags onto the new release.
+1. :octocat: After publishing the new release, a workflow will continue to create and commit the release build, update the references of the corresponding major and minor version tags onto the new release, and merge the release PR.
    - Workflow [GitHub Actions - Release](https://github.com/woocommerce/grow/actions/workflows/github-actions-release.yml)
    - When the new release version is `actions-v2.4.8`, it should update the references of `actions-v2` and `actions-v2.4` onto `actions-v2.4.8`.
    - When the new release version is `actions-v2.5.0`, it should update the reference of `actions-v2` and create `actions-v2.5` tag onto `actions-v2.5.0`.
    - When the new release version is `actions-v3.0.0`, it should create `actions-v3` and `actions-v3.0` tags onto `actions-v3.0.0`.
-1. :technologist: Check if both release workflows are run successfully.
-1. :technologist: Merge the release PR.
+1. :technologist: Check if the release workflow has run successfully.
 
 ### Testing the release process
 

--- a/packages/github-actions/build-php-actions.sh
+++ b/packages/github-actions/build-php-actions.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Loop through all directories, building the package for each one if it has composer.json.
 for d in $(find ./actions -mindepth 1 -maxdepth 1 -type d) ; do


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a preparatory step for the upcoming Node.js v24 upgrade.

- Add `set -euo pipefail` to `github-actions-create-and-commit-build.sh` and `build-php-actions.sh` so a failed build command stops the script immediately instead of being silently ignored.
- Add an EXIT trap that deletes the temporary remote branch (`tmp-gha-release-build`) if the script fails between pushing and deleting it, so a failed run does not leave the branch behind.
- Add a `MergeReleasePR` job to `github-actions-release.yml` that merges the release PR automatically after the version tags are updated, removing the previous manual merge step. The job targets the branch from `github.event.workflow_run.head_branch` and runs only on `workflow_run` events.
- Update `packages/github-actions/README.md` and the release PR body text to describe the automated merge.
