### PR TITLE
Upgrade the `github-actions` package and its actions to Node.js v24

### DIFF
--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -61,15 +61,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '22']
+        node-version: ['24', '22', '20']
         install-deps: ['yes', 'no']
         ignore-scripts: ['yes']
         include:
-          - node-version: '20'
+          - node-version: '24'
             install-deps: 'yes'
             ignore-scripts: 'no'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./packages/github-actions/actions/prepare-node
         with:
           node-version: ${{ matrix.node-version }}
@@ -107,7 +107,7 @@ jobs:
           - php-version: '8.2'
             install-deps: 'yes'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create minimal Composer project for install test
         if: matrix.install-deps == 'yes'
         run: |
@@ -139,7 +139,7 @@ jobs:
     name: prepare-mysql
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./packages/github-actions/actions/prepare-mysql
       - name: Verify MySQL connection
         run: mysql -u root -proot -e "SELECT 1;"
@@ -152,10 +152,10 @@ jobs:
       matrix:
         eslint-version: ['8', '9']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Build the formatter
         working-directory: packages/github-actions
         run: |
@@ -193,10 +193,10 @@ jobs:
       matrix:
         stylelint-version: ['15', '16']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Build the formatter
         working-directory: packages/github-actions
         run: |

--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -6,7 +6,7 @@ Custom GitHub actions that help to composite GitHub workflows across the repos m
 
 ## Actions list
 
-All actions involving Node.js are run in v20.
+All actions involving Node.js are run in v24.
 
 - [`automerge-released-trunk`](actions/automerge-released-trunk) - Merge `trunk` to `develop` after an extension release
 - [`branch-label`](actions/branch-label) - Set PR labels according to the branch name

--- a/packages/github-actions/actions/automerge-released-trunk/README.md
+++ b/packages/github-actions/actions/automerge-released-trunk/README.md
@@ -24,5 +24,5 @@ jobs:
   automerge_trunk:
     runs-on: ubuntu-latest
     steps:
-      - uses: woocommerce/grow/automerge-released-trunk@actions-v2
+      - uses: woocommerce/grow/automerge-released-trunk@actions-v3
 ```

--- a/packages/github-actions/actions/automerge-released-trunk/action.yml
+++ b/packages/github-actions/actions/automerge-released-trunk/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: "Merge the release to develop"
       shell: bash
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}

--- a/packages/github-actions/actions/branch-label/README.md
+++ b/packages/github-actions/actions/branch-label/README.md
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v2
+        uses: woocommerce/grow/branch-label@actions-v3
 ```
 
 #### Permissions:
@@ -37,8 +37,8 @@ In order to add labels to pull requests, this action requires write permissions 
 
 Ref:
 - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
-- https://github.com/actions/labeler/tree/v5#usage
-- https://github.com/actions/labeler/tree/v5#permissions
+- https://github.com/actions/labeler/tree/v6#usage
+- https://github.com/actions/labeler/tree/v6#recommended-permissions
 
 ## Migration from v1 to v2:
 

--- a/packages/github-actions/actions/branch-label/action.yml
+++ b/packages/github-actions/actions/branch-label/action.yml
@@ -11,4 +11,4 @@ runs:
         mkdir -p "$CONFIG_DIR"
         cp "${{ github.action_path }}/labeler.yml" "$CONFIG_DIR"
 
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6

--- a/packages/github-actions/actions/coverage-report/README.md
+++ b/packages/github-actions/actions/coverage-report/README.md
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v3
 
       - name: Run unit tests (with coverage report)
         run: phpdbg -qrr vendor/bin/phpunit --coverage-clover=tests/coverage/report.xml
 
       - name: PHP unit coverage report
-        uses: woocommerce/grow/coverage-report@actions-v2
+        uses: woocommerce/grow/coverage-report@actions-v3
         with:
           base-branch: trunk
           test-comment: "PHP unit test coverage"

--- a/packages/github-actions/actions/coverage-report/action.yml
+++ b/packages/github-actions/actions/coverage-report/action.yml
@@ -42,7 +42,7 @@ runs:
 
     # Download coverage report artifact
     - if: github.event_name == 'pull_request'
-      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21 (major-only release tag; no minor or patch component)
       continue-on-error: true
       with:
         workflow: ${{ inputs.workflow }}
@@ -52,14 +52,14 @@ runs:
 
     # Save coverage report as an artifact
     - if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.report-name }}
         path: "${{ inputs.report-path }}/${{ inputs.report-file }}"
 
     # Coverage report as PR comment
     - if: github.event_name == 'pull_request'
-      uses: lucassabreu/comment-coverage-clover@6da350e7fff3254235663a409af8739e9d289d63 # v0.15.4
+      uses: lucassabreu/comment-coverage-clover@c0f074f770934003d14a2a90121da232e47f53c1 # v0.17.0
       with:
         file: "${{ inputs.report-path }}/${{ inputs.report-file }}"
         base-file: "${{ inputs.report-path }}/${{ inputs.base-branch }}/${{ inputs.report-file }}"

--- a/packages/github-actions/actions/eslint-annotation/README.md
+++ b/packages/github-actions/actions/eslint-annotation/README.md
@@ -24,12 +24,12 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci
-      - uses: woocommerce/grow/eslint-annotation@actions-v2
+      - uses: woocommerce/grow/eslint-annotation@actions-v3
         with:
           formatter-dest: "./my-formatter.cjs"
       - run: eslint --format ./my-formatter.cjs src

--- a/packages/github-actions/actions/get-plugin-releases/README.md
+++ b/packages/github-actions/actions/get-plugin-releases/README.md
@@ -23,13 +23,13 @@ jobs:
     steps:
       - name: Get Release versions from WooCommerce (WordPress.org)
         id: wc-versions
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v3
         with:
           slug: woocommerce
 
       - name: Get Release versions from WooCommerce (GitHub)
         id: wc-gh-versions
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v3
         with:
           source: github
           slug: woocommerce/woocommerce
@@ -38,19 +38,19 @@ jobs:
 
       - name: Get Release versions from WordPress
         id: wp-versions
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v3
         with:
           slug: wordpress
 
       - name: Get Release versions from GLA
         id: gla-versions
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v3
         with:
           slug: google-listings-and-ads
 
       - name: Get L-3 Release versions from WC including RC
         id: wc-versions-l3-rc
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v3
         with:
           slug: woocommerce
           releases: 4
@@ -58,7 +58,7 @@ jobs:
 
       - name: Get L-2 Release versions from WC including patches
         id: wc-versions-patches
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v3
         with:
           slug: woocommerce
           includePatches: true

--- a/packages/github-actions/actions/get-plugin-releases/action.yml
+++ b/packages/github-actions/actions/get-plugin-releases/action.yml
@@ -26,5 +26,5 @@ outputs:
     description: The versions array in the format ["7.4","7.5","7.6"]
 
 runs:
-  using: node20
+  using: node24
   main: get-plugin-releases.mjs

--- a/packages/github-actions/actions/get-release-notes/README.md
+++ b/packages/github-actions/actions/get-release-notes/README.md
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get release notes
         id: get-notes
-        uses: woocommerce/grow/get-release-notes@actions-v2
+        uses: woocommerce/grow/get-release-notes@actions-v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           tag-template: "v{version}"
@@ -86,11 +86,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get release notes
         id: get-notes
-        uses: woocommerce/grow/get-release-notes@actions-v2
+        uses: woocommerce/grow/get-release-notes@actions-v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           tag-template: "v{version}"
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check created release branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             if ( ! context.payload.created ) {
@@ -137,11 +137,11 @@ jobs:
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get release notes
         id: get-notes
-        uses: woocommerce/grow/get-release-notes@actions-v2
+        uses: woocommerce/grow/get-release-notes@actions-v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           tag-template: "v{version}"

--- a/packages/github-actions/actions/get-release-notes/action.yml
+++ b/packages/github-actions/actions/get-release-notes/action.yml
@@ -69,5 +69,5 @@ outputs:
     description: The next tag name inferred via the release notes. For example, 2.0.0, v1.5.0 or my-tool-v1.4.8.
 
 runs:
-  using: node20
+  using: node24
   main: get-release-notes.mjs

--- a/packages/github-actions/actions/hook-documentation/readme.md
+++ b/packages/github-actions/actions/hook-documentation/readme.md
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Checks out a branch instead of a commit in detached HEAD state
           ref: ${{ github.head_ref }}
@@ -50,7 +50,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: woocommerce/grow/hook-documentation@actions-v2
+        uses: woocommerce/grow/hook-documentation@actions-v3
         with:
           debug-output: yes
           source-directories: src/,templates/

--- a/packages/github-actions/actions/merge-trunk-develop-pr/README.md
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/README.md
@@ -24,5 +24,5 @@ jobs:
   automerge_trunk:
     runs-on: ubuntu-latest
     steps:
-      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v2
+      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v3
 ```

--- a/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: "Make the PR"
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const title = `${ context.payload.pull_request.title } - Merge \`trunk\` to \`develop\``;

--- a/packages/github-actions/actions/phpcs-diff/README.md
+++ b/packages/github-actions/actions/phpcs-diff/README.md
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run PHPCS to changed lines of code
-        uses: woocommerce/grow/phpcs-diff@actions-v2
+        uses: woocommerce/grow/phpcs-diff@actions-v3
 ```
 
 #### Specify the PHP version:
@@ -41,7 +41,7 @@ jobs:
 ```yaml
 steps:
   - name: Run PHPCS to changed lines of code
-    uses: woocommerce/grow/phpcs-diff@actions-v2
+    uses: woocommerce/grow/phpcs-diff@actions-v3
     with:
       php-version: 8.1
 ```

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -11,12 +11,12 @@ runs:
   using: composite
   steps:
     # Checkout repository.
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 2
 
     # Set up PHP.
-    - uses: woocommerce/grow/prepare-php@actions-v2
+    - uses: woocommerce/grow/prepare-php@actions-v3
       with:
         php-version: ${{ inputs.php-version }}
 

--- a/packages/github-actions/actions/prepare-extension-release/README.md
+++ b/packages/github-actions/actions/prepare-extension-release/README.md
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-      - uses: woocommerce/grow/prepare-extension-release@actions-v2
+        uses: actions/checkout@v6
+      - uses: woocommerce/grow/prepare-extension-release@actions-v3
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/packages/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/github-actions/actions/prepare-extension-release/action.yml
@@ -58,7 +58,7 @@ runs:
         git push --set-upstream origin "${BRANCH_NAME}"
     - name: Create a pull request for the release
       id: prepare-release-pr
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const action_path = '${{ github.action_path }}';

--- a/packages/github-actions/actions/prepare-mysql/README.md
+++ b/packages/github-actions/actions/prepare-mysql/README.md
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v2
+        uses: woocommerce/grow/prepare-mysql@actions-v3
 
       - name: Create database
         run: mysql -e 'CREATE DATABASE IF NOT EXISTS wordpress_test;' -u root -proot

--- a/packages/github-actions/actions/prepare-node/README.md
+++ b/packages/github-actions/actions/prepare-node/README.md
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Build bundle
         run: npm run build
@@ -34,17 +34,17 @@ jobs:
 
 Must specify either `node-version` or `node-version-file` option to set the version.
 
-[Supported version syntax](https://github.com/actions/setup-node/blob/v3/README.md#supported-version-syntax)
+[Supported version syntax](https://github.com/actions/setup-node/blob/v6/README.md#supported-version-syntax)
 
 #### Specify the node version via a file:
 
 ```yaml
 steps:
   - name: Checkout repository
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
 
   - name: Prepare node
-    uses: woocommerce/grow/prepare-node@actions-v2
+    uses: woocommerce/grow/prepare-node@actions-v3
     with:
       node-version-file: ".nvmrc"
 ```
@@ -54,12 +54,12 @@ steps:
 ```yaml
 steps:
   - name: Checkout repository
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
 
   - name: Prepare node
-    uses: woocommerce/grow/prepare-node@actions-v2
+    uses: woocommerce/grow/prepare-node@actions-v3
     with:
-      node-version: 20
+      node-version: 24
       cache-dependency-path: "./packages/github-actions"
 ```
 
@@ -68,10 +68,10 @@ steps:
 ```yaml
 steps:
   - name: Checkout repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
 
   - name: Prepare node
-    uses: woocommerce/grow/prepare-node@actions-v2
+    uses: woocommerce/grow/prepare-node@actions-v3
     with:
       node-version: "lts/*"
       install-deps: "no"
@@ -85,10 +85,10 @@ steps:
 ```yaml
 steps:
   - name: Checkout repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
 
   - name: Prepare node
-    uses: woocommerce/grow/prepare-node@actions-v2
+    uses: woocommerce/grow/prepare-node@actions-v3
     with:
       node-version: "latest"
       ignore-scripts: "no"

--- a/packages/github-actions/actions/prepare-node/action.yml
+++ b/packages/github-actions/actions/prepare-node/action.yml
@@ -3,7 +3,7 @@ description: Set up Node.js with a specific version, load npm cache, install Nod
 
 inputs:
   node-version:
-    description: "Specify Node.js version. For example: 20, 20.12, 20.12.1, lts/iron, lts/*, latest, current"
+    description: "Specify Node.js version. For example: 24, 24.4, 24.4.1, lts/krypton, lts/*, latest, current"
     default: ""
 
   node-version-file:
@@ -29,7 +29,7 @@ runs:
   using: composite
   steps:
     # Setup node version and caching.
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}

--- a/packages/github-actions/actions/prepare-php/README.md
+++ b/packages/github-actions/actions/prepare-php/README.md
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v3
 
       - name: Run unit tests
         run: vendor/bin/phpunit
@@ -37,10 +37,10 @@ jobs:
 ```yaml
 steps:
   - name: Checkout repository
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
 
   - name: Prepare PHP
-    uses: woocommerce/grow/prepare-php@actions-v2
+    uses: woocommerce/grow/prepare-php@actions-v3
     with:
       php-version: 8.1
 ```
@@ -50,10 +50,10 @@ steps:
 ```yaml
 steps:
   - name: Checkout repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
 
   - name: Prepare PHP
-    uses: woocommerce/grow/prepare-php@actions-v2
+    uses: woocommerce/grow/prepare-php@actions-v3
     with:
       tools: cs2pr
 
@@ -70,10 +70,10 @@ To use Composer v1, set this parameter with `composer:v1`
 ```yaml
 steps:
   - name: Checkout repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
 
   - name: Prepare PHP
-    uses: woocommerce/grow/prepare-php@actions-v2
+    uses: woocommerce/grow/prepare-php@actions-v3
     with:
       coverage: xdebug
 ```
@@ -87,10 +87,10 @@ The `coverage` is `"none"` by default to disable both `Xdebug` and `PCOV`.
 ```yaml
 steps:
   - name: Checkout repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
 
   - name: Prepare PHP
-    uses: woocommerce/grow/prepare-php@actions-v2
+    uses: woocommerce/grow/prepare-php@actions-v3
     with:
       install-deps: "no"
 

--- a/packages/github-actions/actions/prepare-php/action.yml
+++ b/packages/github-actions/actions/prepare-php/action.yml
@@ -50,7 +50,7 @@ runs:
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     # Set up Composer caching.
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ${{ steps.composer-cache-config.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/packages/github-actions/actions/publish-extension-dev-build/README.md
+++ b/packages/github-actions/actions/publish-extension-dev-build/README.md
@@ -24,7 +24,7 @@ jobs:
       # build extension
       - run: npm run build
 
-      - uses: woocommerce/grow/publish-extension-dev-build@actions-v2
+      - uses: woocommerce/grow/publish-extension-dev-build@actions-v3
         with:
           extension-asset-path: my-extension.zip
 

--- a/packages/github-actions/actions/publish-extension-dev-build/action.yml
+++ b/packages/github-actions/actions/publish-extension-dev-build/action.yml
@@ -23,13 +23,13 @@ runs:
   steps:
     # Get unreleased notes
     - id: unreleased-notes
-      uses: woocommerce/grow/get-release-notes@actions-v2
+      uses: woocommerce/grow/get-release-notes@actions-v3
       with:
         repo-token: ${{ github.token }}
         tag-template: "{version}"
 
     # Publish the build to GitHub
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@v9
       with:
         # The main action inputs are not accessible within the "script" input of actions/github-script.
         # So it needs to do forwarding.

--- a/packages/github-actions/actions/stylelint-annotation/README.md
+++ b/packages/github-actions/actions/stylelint-annotation/README.md
@@ -24,12 +24,12 @@ jobs:
   stylelint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci
-      - uses: woocommerce/grow/stylelint-annotation@actions-v2
+      - uses: woocommerce/grow/stylelint-annotation@actions-v3
         with:
           formatter-dest: "./my-formatter.cjs"
       - run: stylelint --custom-formatter ./my-formatter.cjs "**/*.css"

--- a/packages/github-actions/actions/update-version-tags/README.md
+++ b/packages/github-actions/actions/update-version-tags/README.md
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Update version tags
-        uses: woocommerce/grow/update-version-tags@actions-v2
+        uses: woocommerce/grow/update-version-tags@actions-v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/packages/github-actions/actions/update-version-tags/action.yml
+++ b/packages/github-actions/actions/update-version-tags/action.yml
@@ -15,5 +15,5 @@ inputs:
       It's required if this action is triggered by a workflow_run event.
 
 runs:
-  using: node20
+  using: node24
   main: update-version-tags.mjs


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Moves the `github-actions` package and its actions to Node.js v24, off the deprecated Node.js v20 runtime. This is a breaking change for consumers, and it drives the `actions-v3.0.0` release.

- JS runtime actions (`get-release-notes`, `get-plugin-releases`, `update-version-tags`): `using: node20` is changed to `node24`.
- Composite and documentation actions: external action dependencies are bumped to their Node.js v24-compatible majors:
  - `actions/checkout` v6, `actions/setup-node` v6, `actions/github-script` v9, `actions/labeler` v6, `actions/cache` v5, `actions/upload-artifact` v7.
  - SHA-pinned third-party actions are re-pinned to Node.js v24 releases: `dawidd6/action-download-artifact` v21, `lucassabreu/comment-coverage-clover` v0.17.0.
  - `shivammathur/setup-php@v2` already runs on Node.js v24 and is left unchanged.
- README usage examples are updated to `@actions-v3` and to the current external action versions and Node.js v24.
- Internal references between sibling actions are updated to `@actions-v3` (`phpcs-diff` -> `prepare-php`, `publish-extension-dev-build` -> `get-release-notes`).
- The self-test workflow runs every job on Node.js v24 with `checkout` and `setup-node` v6; the `prepare-node` matrix now covers Node.js v24, v22, and v20.

### Detailed test instructions:

1. On the pull request, open the Checks tab and confirm the `GitHub Actions Self-Test` workflow passes, with every job running on Node.js v24.
2. Switch to Node.js v24.
3. From `packages/github-actions`, run `npm ci`.
4. Run npm test to see if all tests can pass.

### Additional details:

- The `@actions-v3` references are intentional forward references; they resolve once `actions-v3.0.0` is released. The repo's own `@actions-v2`-consuming workflows and the release-handling workflows are updated in a follow-up after v3 is published.
- The QIT actions (`run-qit-extension`, `run-qit-annotate`) are intentionally left unchanged; their removal is handled in a separate Pull Request.
