### PR TITLE
Switch repo workflows to actions-v3 and Node.js v24 actions

### DIFF
--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -27,15 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: .nvmrc
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v2
+        uses: woocommerce/grow/eslint-annotation@actions-v3
 
       # Turn off import/no-unresolved rule since this check doesn't install packages for all sub-packages.
       - name: Lint JavaScript and annotate linting errors

--- a/.github/workflows/js-packages-create-release.yml
+++ b/.github/workflows/js-packages-create-release.yml
@@ -23,10 +23,10 @@ jobs:
           echo "tag-prefix=${TAG_PREFIX}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const workspace = '${{ github.workspace }}';
@@ -41,7 +41,7 @@ jobs:
             } );
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release
           path: /tmp/release.json

--- a/.github/workflows/js-packages-prepare-release.yml
+++ b/.github/workflows/js-packages-prepare-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check created release branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             if ( ! context.payload.created ) {
@@ -28,7 +28,7 @@ jobs:
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Derive package config
         id: config
@@ -50,7 +50,7 @@ jobs:
 
       - name: Get release notes
         id: get-notes
-        uses: woocommerce/grow/get-release-notes@actions-v2
+        uses: woocommerce/grow/get-release-notes@actions-v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           package-dir: ${{ steps.config.outputs.package-dir }}
@@ -92,7 +92,7 @@ jobs:
           git push
 
       - name: Create a pull request for release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const workspace = '${{ github.workspace }}';

--- a/.github/workflows/js-packages-release.yml
+++ b/.github/workflows/js-packages-release.yml
@@ -22,7 +22,7 @@ jobs:
       release: ${{ steps.set-result.outputs.release }}
     steps:
       - name: Check tag name or workflow_run conclusion
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { payload, eventName } = context;
@@ -40,7 +40,7 @@ jobs:
       - name: Get release artifact
         id: set-result
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require( 'fs' );
@@ -86,7 +86,7 @@ jobs:
           echo "package-dir=${PACKAGE_DIR}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.resolve-tag.outputs.tag_name }}
 
@@ -102,7 +102,7 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Update version tags
-        uses: woocommerce/grow/update-version-tags@actions-v2
+        uses: woocommerce/grow/update-version-tags@actions-v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ steps.commit-build.outputs.sha }}

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           php-version: 7.4
           tools: cs2pr


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Now that `actions-v3.0.0` is published, point the repository's own workflows at the grow actions' `@actions-v3` and bump their external actions to the Node.js v24 majors. This removes the Node.js v20 deprecation warnings from `@actions-v2` and the old external action versions.



### Detailed test instructions:

1. On this pull request, confirm the `JavaScript Linting` workflow passes (it now runs `prepare-node` and `eslint-annotation` at `@actions-v3`) with no Node.js v20 deprecation warnings.
2. Confirm the `PHP Coding Standards` workflow passes (it now runs `prepare-php` at `@actions-v3`).

### Additional details:

Deferred to separate follow-ups:

- The github-actions release-handling workflows (`github-actions-create-test-build` / `create-release` / `delete-test-build` / `prepare-release` / `release`) still pin `node-version: 20` and old actions.
- `github-action-publish-compat-checker.yml` was skipped becaseu `s0/git-publish-subdir-action` has no Node.js v24 version.