### PR TITLE
Upgrade `github-actions` release workflows to Node.js v24 and refresh release-process in README

### DIFF
--- a/.github/workflows/github-actions-create-release.yml
+++ b/.github/workflows/github-actions-create-release.yml
@@ -12,10 +12,10 @@ jobs:
     if: ${{ github.event.pull_request.head.ref == 'release/actions' && github.event.review.state == 'approved' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const workspace = '${{ github.workspace }}';
@@ -30,7 +30,7 @@ jobs:
             } );
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release
           path: /tmp/release.json

--- a/.github/workflows/github-actions-create-test-build.yml
+++ b/.github/workflows/github-actions-create-test-build.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare node
         uses: ./packages/github-actions/actions/prepare-node
         with:
-          node-version: 20
+          node-version: 24
           cache-dependency-path: ./packages/github-actions/package-lock.json
           install-deps: "no"
 

--- a/.github/workflows/github-actions-delete-test-build.yml
+++ b/.github/workflows/github-actions-delete-test-build.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.ref_type == 'branch'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: trunk
 

--- a/.github/workflows/github-actions-prepare-release.yml
+++ b/.github/workflows/github-actions-prepare-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check created release branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             if ( ! context.payload.created ) {
@@ -27,12 +27,12 @@ jobs:
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare node
         uses: ./packages/github-actions/actions/prepare-node
         with:
-          node-version: 20
+          node-version: 24
           cache-dependency-path: ./packages/github-actions/package-lock.json
           install-deps: "no"
 
@@ -85,7 +85,7 @@ jobs:
           git push
 
       - name: Create a pull request for release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const workspace = '${{ github.workspace }}';

--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -22,7 +22,7 @@ jobs:
       release: ${{ steps.set-result.outputs.release }}
     steps:
       - name: Check tag name or workflow_run conclusion
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { payload, eventName } = context;
@@ -40,7 +40,7 @@ jobs:
       - name: Get release artifact
         id: set-result
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require( 'fs' );
@@ -77,14 +77,14 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.resolve-tag.outputs.tag_name }}
 
       - name: Prepare node
         uses: ./packages/github-actions/actions/prepare-node
         with:
-          node-version: 20
+          node-version: 24
           cache-dependency-path: ./packages/github-actions/package-lock.json
           install-deps: "no"
 

--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -135,7 +135,7 @@ gitGraph
   commit id: "Changelog"
   commit id: "Bump version"
   branch tmp/release-build order: 0
-  commit id: "Release build" type: HIGHLIGHT tag: "actions-v2.2.3"
+  commit id: "Release build" type: HIGHLIGHT tag: "actions-v3.2.3"
   checkout trunk
   merge release/actions
 
@@ -157,19 +157,19 @@ Branch off from the old version, set the merge base for fixing PR to be the same
    - Prepend changelog to [CHANGELOG.md](CHANGELOG.md).
    - Update versions to [package.json](package.json) and [package-lock.json](package-lock.json).
    - Creates a release PR from `release/actions` branch with `trunk` as the base branch.
-1. :technologist: Check if the new changelog content and updated version are correct. Let's assume the current version is `actions-v2.4.7`.
-   - For a patch version like fixing bugs, increases the patch number. For example, `actions-v2.4.8`.
-   - For a minor version like adding new features, increases the minor number and reset the patch number to 0. For example, `actions-v2.5.0`.
-   - For a major version like having incompatible changes, increases the major number and reset the minor and patch numbers to 0. For example, `actions-v3.0.0`.
+1. :technologist: Check if the new changelog content and updated version are correct. Let's assume the current version is `actions-v3.4.7`.
+   - For a patch version like fixing bugs, increases the patch number. For example, `actions-v3.4.8`.
+   - For a minor version like adding new features, increases the minor number and reset the patch number to 0. For example, `actions-v3.5.0`.
+   - For a major version like having incompatible changes, increases the major number and reset the minor and patch numbers to 0. For example, `actions-v4.0.0`.
    - If something needs to be revised, append the changes in the release PR.
 1. :technologist: If it's all good, approve the release PR to proceed with the next workflow.
 1. :octocat: Once the release PR is approved, a workflow will create a new release with a new version tag.
    - Workflow [GitHub Actions - Create Release](https://github.com/woocommerce/grow/actions/workflows/github-actions-create-release.yml)
 1. :octocat: After publishing the new release, a workflow will continue to create and commit the release build, update the references of the corresponding major and minor version tags onto the new release, and merge the release PR.
    - Workflow [GitHub Actions - Release](https://github.com/woocommerce/grow/actions/workflows/github-actions-release.yml)
-   - When the new release version is `actions-v2.4.8`, it should update the references of `actions-v2` and `actions-v2.4` onto `actions-v2.4.8`.
-   - When the new release version is `actions-v2.5.0`, it should update the reference of `actions-v2` and create `actions-v2.5` tag onto `actions-v2.5.0`.
-   - When the new release version is `actions-v3.0.0`, it should create `actions-v3` and `actions-v3.0` tags onto `actions-v3.0.0`.
+   - When the new release version is `actions-v3.4.8`, it should update the references of `actions-v3` and `actions-v3.4` onto `actions-v3.4.8`.
+   - When the new release version is `actions-v3.5.0`, it should update the reference of `actions-v3` and create `actions-v3.5` tag onto `actions-v3.5.0`.
+   - When the new release version is `actions-v4.0.0`, it should create `actions-v4` and `actions-v4.0` tags onto `actions-v4.0.0`.
 1. :technologist: Check if the release workflow has run successfully.
 
 ### Testing the release process


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Two post-`actions-v3` cleanups for the github-actions package.

**Release-handling workflows to Node.js v24:**

- `github-actions-create-test-build`, `create-release`, `delete-test-build`, `prepare-release`, `release`: `node-version` 20 -> 24, and external actions to checkout v6, github-script v9, upload-artifact v7.
- These workflows reference the in-repo actions by local path (they self-validate the version being released), so they keep the local references and do not switch to `@actions-v3`.

**README "Official release process" examples to v3:**

- Bump the example version numbers from `v2.x` to `v3.x`, changing the major number only (minor and patch examples unchanged), now that `actions-v3` is the current line. The major-bump example becomes `actions-v4.0.0`.

### Additional details:

`github-action-publish-compat-checker.yml` is intentionally still deferred: its `s0/git-publish-subdir-action` has no Node.js v24 version.