### PR TITLE
Update babel toolchain to clear npm audit advisory for `@babel/core`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,20 +20,6 @@
         "node": ">=24"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -2835,64 +2821,33 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.48.0.tgz",
-      "integrity": "sha512-arwTuIihbSj/F3S89p1DqmfViCSqfbcCoZEeIcx07kyOR+D+7T+ZRLQ1sX62bZ5NkSC/SsdkBp6GkMCfE8NWqQ==",
+      "version": "8.48.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.48.1.tgz",
+      "integrity": "sha512-wC8l2sMR8XJO7ck4rHnYUm+287iN24CzsGejlw64hetRP2Oz/QeAXp2jbghRb4qW+2Ab6hLPtTEuJQlevvA1Yg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/core": "7.25.7",
-        "@babel/plugin-syntax-import-attributes": "7.26.0",
-        "@babel/plugin-transform-react-jsx": "7.25.7",
-        "@babel/plugin-transform-runtime": "7.25.7",
-        "@babel/preset-env": "7.25.7",
-        "@babel/preset-typescript": "7.25.7",
-        "@wordpress/browserslist-config": "^6.48.0",
-        "@wordpress/warning": "^3.48.0",
+        "@babel/core": "^7.25.7",
+        "@babel/plugin-syntax-import-attributes": "^7.26.0",
+        "@babel/plugin-transform-react-jsx": "^7.25.7",
+        "@babel/plugin-transform-runtime": "^7.25.7",
+        "@babel/preset-env": "^7.25.7",
+        "@babel/preset-typescript": "^7.25.7",
+        "@wordpress/browserslist-config": "^6.48.1",
+        "@wordpress/warning": "^3.48.1",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
-        "react": "^18.3.0"
+        "react": "^18.3.1"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/babel-preset-default/node_modules/@babel/core": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-      "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.25.7",
-        "@babel/generator": "^7.25.7",
-        "@babel/helper-compilation-targets": "^7.25.7",
-        "@babel/helper-module-transforms": "^7.25.7",
-        "@babel/helpers": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/template": "^7.25.7",
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.48.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.48.0.tgz",
-      "integrity": "sha512-bPcrwFqlG9i4qLrcrYBj8lOYhB547SYelEZ+HCesfrkUHr5YDM2mnUdqKhj0+E6/T/iSBAht9uK4SEqj/hShqA==",
+      "version": "6.48.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.48.1.tgz",
+      "integrity": "sha512-Rbh//p4Ugzw2xoKhBurtRXp/UxKxPAAPrtFAYDAXyByxIjEbEzvngHAYdFPn1VcwNxxB9qsEnzIaiZrgn2E2Qg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -3232,9 +3187,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.48.0.tgz",
-      "integrity": "sha512-En+A99j8aySNzUH0iXok0H2Xi+Uw2useKqYsvPm33VEMa0a0XIwa2I9srK5STp8RydCm1dK+/41K9e5xeFu23Q==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.48.1.tgz",
+      "integrity": "sha512-5YyMCOHycuHG+AjsVEUafpTqV4b4qjVv/tel5m1L8k8g8dUW5T/XKguFo1nhCqQc4HqoGBrJtKjaf6dMmg8uWg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`npm audit` on the root project reported a low-severity advisory in a dev dependency:

- `@babel/core` (GHSA-4x5r-pxfx-6jf8)

`package-lock.json` kept a stale nested `@babel/core` 7.25.7 that `@wordpress/babel-preset-default` 8.48.0 pinned exactly. Bumping that package to 8.48.1 loosens the pin to `^7.25.7`, so it dedupes to the safe top-level version. The now-orphaned `@ampproject/remapping` entry is dropped as well, since 7.29.7 uses `@jridgewell/remapping` instead.

### Detailed test instructions:

1. Run `npm install`.
2. Run `npm audit`.
3. Confirm the output reports no vulnerabilities.
4. Run `npm run lint:js` and confirm it completes without errors.

<img width="429" height="217" alt="image" src="https://github.com/user-attachments/assets/e3ab774b-b37e-4241-86ce-7648a699379e" />
<img width="376" height="93" alt="image" src="https://github.com/user-attachments/assets/259a6ccf-cd85-40d6-9134-929f7988f7cd" />
