### PR TITLE
Remove dead link to deleted `source/actions-v1` branch

### DIFF
--- a/packages/github-actions/README.md
+++ b/packages/github-actions/README.md
@@ -145,8 +145,6 @@ gitGraph
 
 Branch off from the old version, set the merge base for fixing PR to be the same as the old version, and run the release process for that version after merging.
 
-- [v1 source branch](https://github.com/woocommerce/grow/tree/source/actions-v1/packages/github-actions)
-
 ## Release
 
 ### Official release process


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `source/actions-v1` branch has been deleted, so the "v1 source branch" link under "Fix bugs for old versions" in the `github-actions` README now points to a nonexistent branch. This removes that dead link.
