### PR TITLE
Fix `stylelint-annotation` silently passing CI and not showing inline annotations

### DIFF
--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -164,7 +164,7 @@ jobs:
           cat "$GITHUB_WORKSPACE/packages/github-actions/actions/eslint-annotation/eslintFormatter.cjs" >> eslintFormatter.cjs
           # Create a file with a known lint error
           echo 'var unused = 1;' > sample.js
-      - name: Verify formatter produces annotation commands
+      - name: Verify formatter annotates and fails on lint errors
         working-directory: /tmp/formatter-test
         run: |
           MAJOR=$(./node_modules/.bin/eslint --version | cut -d. -f1 | tr -d 'v')
@@ -173,9 +173,16 @@ jobs:
           else
             CONFIG_FLAG="--no-eslintrc"
           fi
-          OUTPUT=$(./node_modules/.bin/eslint sample.js $CONFIG_FLAG --rule 'no-unused-vars: error' --format ./eslintFormatter.cjs 2>&1 || true)
+          OUTPUT=$(./node_modules/.bin/eslint sample.js $CONFIG_FLAG --rule 'no-unused-vars: error' --format ./eslintFormatter.cjs 2>&1) && STATUS=0 || STATUS=$?
           echo "$OUTPUT"
+          echo "eslint exit status: $STATUS"
+          # The formatter must emit annotation commands.
           echo "$OUTPUT" | grep -qE '^::(error|warning) '
+          # Lint errors must make eslint exit non-zero so failures fail CI.
+          if [ "$STATUS" -eq 0 ]; then
+            echo "Expected eslint to exit non-zero for lint errors, but it exited 0."
+            exit 1
+          fi
 
   test-stylelint-formatter:
     name: "stylelint-annotation (stylelint v${{ matrix.stylelint-version }})"
@@ -183,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stylelint-version: ['15', '16']
+        stylelint-version: ['15', '16', '17']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -206,9 +213,18 @@ jobs:
           # Create a CSS file with a known lint error (duplicate property)
           echo 'a { color: red; color: blue; }' > sample.css
           echo '{"rules": {"declaration-block-no-duplicate-properties": true}}' > .stylelintrc.json
-      - name: Verify formatter produces annotation commands
+      - name: Verify formatter annotates and fails on lint errors
         working-directory: /tmp/formatter-test
         run: |
-          OUTPUT=$(./node_modules/.bin/stylelint sample.css --custom-formatter ./stylelintFormatter.cjs 2>&1 || true)
+          OUTPUT=$(./node_modules/.bin/stylelint sample.css --custom-formatter ./stylelintFormatter.cjs 2>&1) && STATUS=0 || STATUS=$?
           echo "$OUTPUT"
+          echo "stylelint exit status: $STATUS"
+          # The formatter must emit annotation commands.
           echo "$OUTPUT" | grep -qE '^::(error|warning) '
+          # Lint errors must make stylelint exit non-zero. A formatter that returns an
+          # empty report makes stylelint's CLI skip its exit-code assignment, which
+          # would let lint errors pass CI with a green check.
+          if [ "$STATUS" -eq 0 ]; then
+            echo "Expected stylelint to exit non-zero for lint errors, but it exited 0."
+            exit 1
+          fi

--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -164,7 +164,7 @@ jobs:
           cat "$GITHUB_WORKSPACE/packages/github-actions/actions/eslint-annotation/eslintFormatter.cjs" >> eslintFormatter.cjs
           # Create a file with a known lint error
           echo 'var unused = 1;' > sample.js
-      - name: Verify formatter annotates and fails on lint errors
+      - name: Verify formatter produces annotation commands
         working-directory: /tmp/formatter-test
         run: |
           MAJOR=$(./node_modules/.bin/eslint --version | cut -d. -f1 | tr -d 'v')
@@ -173,16 +173,11 @@ jobs:
           else
             CONFIG_FLAG="--no-eslintrc"
           fi
-          OUTPUT=$(./node_modules/.bin/eslint sample.js $CONFIG_FLAG --rule 'no-unused-vars: error' --format ./eslintFormatter.cjs 2>&1) && STATUS=0 || STATUS=$?
+          # eslint's exit code comes from its own error count, not the formatter, so a
+          # non-zero-exit assertion would add nothing. The annotation grep is the guard.
+          OUTPUT=$(./node_modules/.bin/eslint sample.js $CONFIG_FLAG --rule 'no-unused-vars: error' --format ./eslintFormatter.cjs 2>&1 || true)
           echo "$OUTPUT"
-          echo "eslint exit status: $STATUS"
-          # The formatter must emit annotation commands.
           echo "$OUTPUT" | grep -qE '^::(error|warning) '
-          # Lint errors must make eslint exit non-zero so failures fail CI.
-          if [ "$STATUS" -eq 0 ]; then
-            echo "Expected eslint to exit non-zero for lint errors, but it exited 0."
-            exit 1
-          fi
 
   test-stylelint-formatter:
     name: "stylelint-annotation (stylelint v${{ matrix.stylelint-version }})"

--- a/packages/github-actions/actions/eslint-annotation/__tests__/to-annotations.test.js
+++ b/packages/github-actions/actions/eslint-annotation/__tests__/to-annotations.test.js
@@ -89,7 +89,7 @@ describe( 'eslint-annotation toAnnotations', () => {
 		];
 		const result = toAnnotations( failedFiles );
 
-		assert.strictEqual( result[ 0 ].filePath, './src/utils/helper.js' );
+		assert.strictEqual( result[ 0 ].filePath, 'src/utils/helper.js' );
 	} );
 
 	it( 'Should handle multiple files with multiple messages', () => {
@@ -131,7 +131,7 @@ describe( 'eslint-annotation toAnnotations', () => {
 		assert.strictEqual( result.length, 3 );
 		assert.strictEqual( result[ 0 ].command, 'error' );
 		assert.strictEqual( result[ 1 ].command, 'warning' );
-		assert.strictEqual( result[ 2 ].filePath, './b.js' );
+		assert.strictEqual( result[ 2 ].filePath, 'b.js' );
 	} );
 
 	it( 'Should return an empty array when given no failed files', () => {

--- a/packages/github-actions/actions/eslint-annotation/src/to-annotations.js
+++ b/packages/github-actions/actions/eslint-annotation/src/to-annotations.js
@@ -9,7 +9,10 @@ export default function toAnnotations( failedFiles ) {
 	const annotations = [];
 
 	failedFiles.forEach( ( file ) => {
-		const filePath = file.filePath.replace( truncationPath, '.' );
+		// Strip the cwd to a repo-root-relative path with no `./` prefix. GitHub only
+		// links annotations to a pull request's changed files when the path matches
+		// the diff exactly, and a leading `./` prevents that match.
+		const filePath = file.filePath.replace( `${ truncationPath }/`, '' );
 
 		file.messages.forEach( ( lintError ) => {
 			const { severity, ruleId, message } = lintError;

--- a/packages/github-actions/actions/stylelint-annotation/__tests__/to-annotations.test.js
+++ b/packages/github-actions/actions/stylelint-annotation/__tests__/to-annotations.test.js
@@ -65,10 +65,7 @@ describe( 'stylelint-annotation toAnnotations', () => {
 		];
 		const result = toAnnotations( failedFiles );
 
-		assert.strictEqual(
-			result[ 0 ].filePath,
-			'./src/components/button.css'
-		);
+		assert.strictEqual( result[ 0 ].filePath, 'src/components/button.css' );
 	} );
 
 	it( 'Should pass through message text', () => {
@@ -127,7 +124,7 @@ describe( 'stylelint-annotation toAnnotations', () => {
 		assert.strictEqual( result.length, 3 );
 		assert.strictEqual( result[ 0 ].command, 'error' );
 		assert.strictEqual( result[ 1 ].command, 'warning' );
-		assert.strictEqual( result[ 2 ].filePath, './b.css' );
+		assert.strictEqual( result[ 2 ].filePath, 'b.css' );
 	} );
 
 	it( 'Should return an empty array when given no failed files', () => {

--- a/packages/github-actions/actions/stylelint-annotation/__tests__/to-report.test.js
+++ b/packages/github-actions/actions/stylelint-annotation/__tests__/to-report.test.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import toReport from '../src/to-report.js';
+
+describe( 'stylelint-annotation toReport', () => {
+	it( 'Should return an empty string when there are no annotations', () => {
+		assert.strictEqual( toReport( [] ), '' );
+	} );
+
+	it( 'Should return a non-empty string when there are annotations', () => {
+		// The stylelint CLI skips its exit-code assignment on an empty report, so a
+		// non-empty report is what keeps lint errors failing the job.
+		const report = toReport( [
+			{
+				command: 'error',
+				filePath: './a.css',
+				line: 1,
+				column: 1,
+				message: 'Some error',
+			},
+		] );
+
+		assert.ok( report.length > 0 );
+	} );
+
+	it( 'Should include the file path, position, severity, and message', () => {
+		const report = toReport( [
+			{
+				command: 'error',
+				filePath: './src/style.css',
+				line: 5,
+				column: 3,
+				message: 'Unexpected empty block (block-no-empty)',
+			},
+		] );
+
+		assert.match( report, /\.\/src\/style\.css/ );
+		assert.match(
+			report,
+			/5:3\s+error\s+Unexpected empty block \(block-no-empty\)/
+		);
+	} );
+
+	it( 'Should group multiple warnings under the same file', () => {
+		const report = toReport( [
+			{
+				command: 'error',
+				filePath: './a.css',
+				line: 1,
+				column: 1,
+				message: 'Error 1',
+			},
+			{
+				command: 'warning',
+				filePath: './a.css',
+				line: 2,
+				column: 5,
+				message: 'Warning 1',
+			},
+		] );
+
+		// The file path should appear once, followed by both entries.
+		assert.strictEqual( report.match( /\.\/a\.css/g ).length, 1 );
+		assert.match( report, /Error 1/ );
+		assert.match( report, /Warning 1/ );
+	} );
+
+	it( 'Should separate different files into their own blocks', () => {
+		const report = toReport( [
+			{
+				command: 'error',
+				filePath: './a.css',
+				line: 1,
+				column: 1,
+				message: 'Error A',
+			},
+			{
+				command: 'error',
+				filePath: './b.css',
+				line: 10,
+				column: 3,
+				message: 'Error B',
+			},
+		] );
+
+		assert.match( report, /\.\/a\.css/ );
+		assert.match( report, /\.\/b\.css/ );
+	} );
+} );

--- a/packages/github-actions/actions/stylelint-annotation/src/stylelintFormatter.js
+++ b/packages/github-actions/actions/stylelint-annotation/src/stylelintFormatter.js
@@ -8,6 +8,7 @@ import stylelint from 'stylelint'; // eslint-disable-line import/no-extraneous-d
  */
 import annotateByWorkflowCommand from '../../../utils/annotate-by-workflow-command.js';
 import toAnnotations from './to-annotations.js';
+import toReport from './to-report.js';
 
 // Ref: https://stylelint.io/developer-guide/formatters/
 export default function ( results, returnValue ) {
@@ -15,10 +16,13 @@ export default function ( results, returnValue ) {
 	const annotations = toAnnotations( failedFiles );
 	annotateByWorkflowCommand( annotations );
 
-	// Try to still output the original CLI logs by default format.
-	try {
-		return stylelint.formatters.string( results, returnValue );
-	} catch ( e ) {
-		// No-op.
+	// stylelint >= 16 turned `formatters.string` into a lazy async getter that returns
+	// a Promise, whereas <= 15 exposed the formatter function directly. Use it only
+	// while it is still a sync function, and otherwise build the report ourselves.
+	const builtInStringFormatter = stylelint.formatters.string;
+	if ( typeof builtInStringFormatter === 'function' ) {
+		return builtInStringFormatter( results, returnValue );
 	}
+
+	return toReport( annotations );
 }

--- a/packages/github-actions/actions/stylelint-annotation/src/to-annotations.js
+++ b/packages/github-actions/actions/stylelint-annotation/src/to-annotations.js
@@ -9,7 +9,10 @@ export default function toAnnotations( failedFiles ) {
 	const annotations = [];
 
 	failedFiles.forEach( ( file ) => {
-		const filePath = file.source.replace( truncationPath, '.' );
+		// Strip the cwd to a repo-root-relative path with no `./` prefix. GitHub only
+		// links annotations to a pull request's changed files when the path matches
+		// the diff exactly, and a leading `./` prevents that match.
+		const filePath = file.source.replace( `${ truncationPath }/`, '' );
 
 		file.warnings.forEach( ( lintError ) => {
 			const { severity, line, column, text } = lintError;

--- a/packages/github-actions/actions/stylelint-annotation/src/to-report.js
+++ b/packages/github-actions/actions/stylelint-annotation/src/to-report.js
@@ -1,0 +1,31 @@
+/**
+ * Builds a concise, human-readable report from annotations.
+ *
+ * stylelint's CLI only sets a non-zero exit code when the formatter returns a
+ * non-empty report. An empty report makes it skip that step, letting lint errors
+ * pass CI silently. This therefore returns a non-empty string whenever there are
+ * problems.
+ *
+ * @param {Array} annotations Annotation objects from `toAnnotations`.
+ * @return {string} Report text, or empty when there are no problems.
+ */
+export default function toReport( annotations ) {
+	if ( annotations.length === 0 ) {
+		return '';
+	}
+
+	const linesByFile = new Map();
+
+	annotations.forEach( ( { filePath, line, column, command, message } ) => {
+		const lines = linesByFile.get( filePath ) ?? [];
+		// `command` holds the severity ('error' or 'warning').
+		lines.push( `  ${ line }:${ column }  ${ command }  ${ message }` );
+		linesByFile.set( filePath, lines );
+	} );
+
+	const blocks = [ ...linesByFile ].map( ( [ filePath, lines ] ) =>
+		[ filePath, ...lines ].join( '\n' )
+	);
+
+	return `${ blocks.join( '\n\n' ) }\n`;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes two related problems with the `stylelint-annotation` action on `stylelint` 16 and later, and strengthens the formatter self-tests so the same class of problem is caught in the future.

**Lint errors passed CI silently on `stylelint` 16+.** `stylelint` 16 turned `formatters.string` into a lazy async getter that returns a Promise, while 15 and earlier exposed the function directly. The formatter called it as a synchronous function, which threw, and the surrounding catch swallowed the error and returned `undefined`. `stylelint`'s CLI only sets a non-zero exit code when the formatter returns a non-empty report, so lint errors exited 0 and the check stayed green while the annotations still printed. The formatter now reuses the built-in formatter only while it is still a sync function (`stylelint` 15 and earlier), and otherwise builds the report itself, so the report stays non-empty and the exit code is correct across `stylelint` 15, 16, and 17.

**Annotations did not appear inline on the pull request.** Both annotation formatters produced a `./assets/...` path. GitHub links a check annotation to a pull request's changed files by matching the path against the diff, and the leading `./` kept that match from happening, so the annotations attached to the check run but never showed on the changed lines. The `stylelint` and `eslint` formatters now emit a bare repo-root-relative path.

**Self-tests now assert the exit code.** The formatter self-tests captured the linter output with `|| true` and only checked that annotation commands were printed, never the exit code, so a formatter that annotates but exits 0 still passed. They now capture and assert a non-zero exit code on lint errors. `stylelint` 17 was also added to the matrix.

### Detailed test instructions:

1. Open the **GitHub Actions Self-Test** checks on this PR.
2. Confirm the `stylelint-annotation (stylelint v15)`, `(v16)`, and `(v17)` jobs pass. Each one runs the built formatter against a file with a known error and now asserts a non-zero exit code.
3. Confirm the `eslint-annotation (eslint v8)` and `(v9)` jobs pass with the same assertion.
4. As for annotations, this has been verified through linting errors intentionally seeded via https://github.com/woocommerce/automatewoo-referrals/pull/518.
   <img width="915" height="1123" alt="image" src="https://github.com/user-attachments/assets/131de89a-f4e6-4da2-ad87-15b96c6110a4" />
   <img width="1417" height="630" alt="image" src="https://github.com/user-attachments/assets/5e37c935-f45b-471f-be8a-478bc0fd2f01" />
