### PR TITLE
Fix npm audit vulnerabilities and clean up the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ _Replace this with a good description of your changes & reasoning._
 <!--
 Optional.
 
-For changes related to a releasable package, please use the corresponding changelog labels, for example, `[actions] changelog: *` labels for the `github-actions` package, and likewise for the `jsdoc` and `tracking-jsdoc` packages.
+For changes related to a releasable package, please use the corresponding changelog labels, for example, `[actions] changelog: *` for the `github-actions` package, and likewise for the `jsdoc` and `tracking-jsdoc` packages.
 
 Add the `changelog: none` label if no changelog entry is needed.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,20 +24,8 @@ _Replace this with a good description of your changes & reasoning._
 
 <!--
 Optional.
-Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
-Each line should start with change type prefix`(Fix|Add|…) - `, for example:
-> Break - A change breaking previous API or functionality.
-> Add - A new feature, function or functionality was added.
-> Update - Big changes to something that wasn't broken.
-> Fix - Took care of something that wasn't working.
-> Tweak - Small change, that isn't actually very important.
-> Dev - Developer-facing only change.
-> Doc - Updated customer or developer facing documentation
 
-For changes related to the `github-actions` package, please use `[actions] changelog: *` labels.
+For changes related to a releasable package, please use the corresponding changelog labels, for example, `[actions] changelog: *` labels for the `github-actions` package, and likewise for the `jsdoc` and `tracking-jsdoc` packages.
 
 Add the `changelog: none` label if no changelog entry is needed.
 -->
-### Changelog entry
-
->

--- a/package-lock.json
+++ b/package-lock.json
@@ -3099,9 +3099,9 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3576,9 +3576,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5885,9 +5885,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR contains two repo housekeeping changes.

1. **Fix npm audit issues.** Update the flagged transitive dependencies in place in `package-lock.json`:
   - `brace-expansion` 2.1.1 -> 2.1.2 and 1.1.15 -> 1.1.16
   - `js-yaml` 4.2.0 -> 4.3.0
2. **Remove the unused changelog entry section from the PR template.** The changelog for releasable packages is generated from PR labels during the release flow, not from text written in the PR body, so the "Changelog entry" section and the change type prefix guidance are dropped. The label guidance is reworded to cover all releasable packages.

### Detailed test instructions:

1. Check out this branch and run `npm install`.
2. Run `npm audit` and confirm it reports no vulnerabilities.
3. Run `npm run lint:js` and confirm it exits without errors.
