### PR TITLE
Bump `linkify-it` from 5.0.1 to 5.0.2 and add a chore changelog category

### DIFF
--- a/packages/js/jsdoc/package-lock.json
+++ b/packages/js/jsdoc/package-lock.json
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",

--- a/packages/js/jsdoc/release-notes-config.yml
+++ b/packages/js/jsdoc/release-notes-config.yml
@@ -33,3 +33,7 @@ changelog:
     - title: Documentation 📚
       labels:
         - "[jsdoc] changelog: docs"
+
+    - title: Chores 🧹
+      labels:
+        - "[jsdoc] changelog: chore"

--- a/packages/js/tracking-jsdoc/release-notes-config.yml
+++ b/packages/js/tracking-jsdoc/release-notes-config.yml
@@ -33,3 +33,7 @@ changelog:
     - title: Documentation 📚
       labels:
         - "[tracking-jsdoc] changelog: docs"
+
+    - title: Chores 🧹
+      labels:
+        - "[tracking-jsdoc] changelog: chore"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR contains two changes around dependency maintenance for the js packages.

1. **Fix the npm audit issue in the `jsdoc` package.** Update `linkify-it` 5.0.1 -> 5.0.2 in place in `packages/js/jsdoc/package-lock.json` to fix a npm audit vulnerability. The fix stays within the version range declared by `markdown-it`, so no override is needed and `package.json` is unchanged. This change only affects development and CI within this repo.
2. **Add a chore category to the js packages' release notes configs.** Dependency maintenance like npm audit fixes has no matching category in the generated release notes, so map the `[jsdoc] changelog: chore` and `[tracking-jsdoc] changelog: chore` labels to a new Chores section. Both labels have been created in this repo.

### Detailed test instructions:

1. Check out this branch and run `npm install` in `packages/js/jsdoc`.
2. Run `npm audit` in the same directory and confirm it reports no vulnerabilities.
3. Run `npm run dev:doc:tracking` in the same directory and confirm it exits without errors and leaves `samples/jsdoc/TRACKING.md` unchanged.
