### PR TITLE
Run PHP coding standards when dependencies change

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -6,10 +6,14 @@ on:
       - "trunk"
     paths:
       - "**.php"
+      - composer.json
+      - composer.lock
       - .github/workflows/php-coding-standards.yml
   pull_request:
     paths:
       - "**.php"
+      - composer.json
+      - composer.lock
       - .github/workflows/php-coding-standards.yml
 
 concurrency:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The PHP coding standards job only runs when a `**.php` file changes. That leaves a gap: a pull request that changes the project's dependencies is never linted, even though dependencies are what supply the coding standards themselves.

This is not hypothetical. The recent WPCS 3.4.1 update ([GHSA-3pwp-g2mj-5p3v](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v)) touched `composer.lock` only. It replaced the entire coding-standards ruleset and no lint job ran on it.

This adds `composer.json` and `composer.lock` to the filter.

No changelog entry: this touches repo CI config, not the `github-actions`, `jsdoc` or `tracking-jsdoc` packages.

### Detailed test instructions:

This changes when the workflow fires, not what it does, so the check is behavioural:

1. Confirm the workflow still parses — GitHub rejects invalid YAML, so a green Actions tab here is the first signal.
2. On this PR the job **should** run: it edits `.github/workflows/php-coding-standards.yml`, which was already in the filter.
3. To prove the new behaviour, push a commit here changing only `composer.lock` (a whitespace edit is enough) and confirm the job still triggers. Before this change it would not have.
4. Confirm nothing else changed: the diff should be four added lines, two per trigger.

### Additional details:

No change to what phpcs does or which rules apply — only to when the job is triggered. The cost is that dependency-only pull requests now run one extra short job.

An earlier version of this PR also added `phpcs.xml.dist` to the filter. That is pulled out and left for a separate discussion: changing the lint config can surface pre-existing violations across the whole tree, and that deserves its own decision rather than riding along here.

