### PR TITLE
Update `squizlabs/php_codesniffer` to clear a composer audit advisory

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -818,16 +818,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -893,7 +893,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`composer audit` on the root project reported one security advisory:

- squizlabs/php_codesniffer (CVE-2026-67434, OS command injection)

The patched version 3.13.6 already satisfies the existing constraints, so no `composer.json` change is needed. The change is limited to `composer.lock`, a single patch bump from 3.13.5 to 3.13.6.

### Detailed test instructions:

1. Run `composer install`.
2. Run `composer audit`.
3. Confirm the output reports no advisories:
   ```
   No security vulnerability advisories found.
   ```
4. Run `npm run lint:php`.
5. Confirm PHP linting still passes with the updated PHP_CodeSniffer:
   ```
   .............................. 30 / 30 (100%)

   Time: 1.13 secs; Memory: 18MB
   ```
