### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/github-action-publish-compat-checker.yml
+++ b/.github/workflows/github-action-publish-compat-checker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Publish Compat Checker package
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Deploy
       uses: s0/git-publish-subdir-action@92faf786f11dfa44fc366ac3eb274d193ca1af7e # v.2.6.0

--- a/.github/workflows/github-actions-create-release.yml
+++ b/.github/workflows/github-actions-create-release.yml
@@ -12,10 +12,10 @@ jobs:
     if: ${{ github.event.pull_request.head.ref == 'release/actions' && github.event.review.state == 'approved' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create release
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const workspace = '${{ github.workspace }}';
@@ -30,7 +30,7 @@ jobs:
             } );
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release
           path: /tmp/release.json

--- a/.github/workflows/github-actions-create-test-build.yml
+++ b/.github/workflows/github-actions-create-test-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare node
         uses: ./packages/github-actions/actions/prepare-node

--- a/.github/workflows/github-actions-delete-test-build.yml
+++ b/.github/workflows/github-actions-delete-test-build.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.ref_type == 'branch'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: trunk
 

--- a/.github/workflows/github-actions-prepare-release.yml
+++ b/.github/workflows/github-actions-prepare-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check created release branch
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             if ( ! context.payload.created ) {
@@ -27,7 +27,7 @@ jobs:
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare node
         uses: ./packages/github-actions/actions/prepare-node
@@ -85,7 +85,7 @@ jobs:
           git push
 
       - name: Create a pull request for release
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const workspace = '${{ github.workspace }}';

--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -22,7 +22,7 @@ jobs:
       release: ${{ steps.set-result.outputs.release }}
     steps:
       - name: Check tag name or workflow_run conclusion
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { payload, eventName } = context;
@@ -40,7 +40,7 @@ jobs:
       - name: Get release artifact
         id: set-result
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require( 'fs' );
@@ -77,7 +77,7 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.resolve-tag.outputs.tag_name }}
 

--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -21,8 +21,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
       - name: Install dependencies
@@ -36,8 +36,8 @@ jobs:
     name: Build Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
             install-deps: 'yes'
             ignore-scripts: 'no'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./packages/github-actions/actions/prepare-node
         with:
           node-version: ${{ matrix.node-version }}
@@ -99,7 +99,7 @@ jobs:
           - php-version: '8.2'
             install-deps: 'yes'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Create minimal Composer project for install test
         if: matrix.install-deps == 'yes'
         run: |
@@ -131,7 +131,7 @@ jobs:
     name: prepare-mysql
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./packages/github-actions/actions/prepare-mysql
       - name: Verify MySQL connection
         run: mysql -u root -proot -e "SELECT 1;"
@@ -144,8 +144,8 @@ jobs:
       matrix:
         eslint-version: ['8', '9']
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
       - name: Build the formatter
@@ -187,8 +187,8 @@ jobs:
       matrix:
         stylelint-version: ['15', '16', '17']
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
       - name: Build the formatter

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -27,15 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v3
+        uses: woocommerce/grow/prepare-node@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           node-version-file: .nvmrc
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v3
+        uses: woocommerce/grow/eslint-annotation@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
 
       # Turn off import/no-unresolved rule since this check doesn't install packages for all sub-packages.
       - name: Lint JavaScript and annotate linting errors

--- a/.github/workflows/js-packages-create-release.yml
+++ b/.github/workflows/js-packages-create-release.yml
@@ -23,10 +23,10 @@ jobs:
           echo "tag-prefix=${TAG_PREFIX}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create release
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const workspace = '${{ github.workspace }}';
@@ -41,7 +41,7 @@ jobs:
             } );
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release
           path: /tmp/release.json

--- a/.github/workflows/js-packages-prepare-release.yml
+++ b/.github/workflows/js-packages-prepare-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check created release branch
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             if ( ! context.payload.created ) {
@@ -28,7 +28,7 @@ jobs:
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Derive package config
         id: config
@@ -50,7 +50,7 @@ jobs:
 
       - name: Get release notes
         id: get-notes
-        uses: woocommerce/grow/get-release-notes@actions-v3
+        uses: woocommerce/grow/get-release-notes@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           package-dir: ${{ steps.config.outputs.package-dir }}
@@ -92,7 +92,7 @@ jobs:
           git push
 
       - name: Create a pull request for release
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const workspace = '${{ github.workspace }}';

--- a/.github/workflows/js-packages-release.yml
+++ b/.github/workflows/js-packages-release.yml
@@ -22,7 +22,7 @@ jobs:
       release: ${{ steps.set-result.outputs.release }}
     steps:
       - name: Check tag name or workflow_run conclusion
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { payload, eventName } = context;
@@ -40,7 +40,7 @@ jobs:
       - name: Get release artifact
         id: set-result
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require( 'fs' );
@@ -86,7 +86,7 @@ jobs:
           echo "package-dir=${PACKAGE_DIR}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.resolve-tag.outputs.tag_name }}
 
@@ -102,7 +102,7 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Update version tags
-        uses: woocommerce/grow/update-version-tags@actions-v3
+        uses: woocommerce/grow/update-version-tags@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ steps.commit-build.outputs.sha }}

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v3
+        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
         with:
           php-version: 7.4
           tools: cs2pr

--- a/packages/github-actions/actions/automerge-released-trunk/action.yml
+++ b/packages/github-actions/actions/automerge-released-trunk/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: "Merge the release to develop"
       shell: bash
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}

--- a/packages/github-actions/actions/branch-label/action.yml
+++ b/packages/github-actions/actions/branch-label/action.yml
@@ -11,4 +11,4 @@ runs:
         mkdir -p "$CONFIG_DIR"
         cp "${{ github.action_path }}/labeler.yml" "$CONFIG_DIR"
 
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6

--- a/packages/github-actions/actions/coverage-report/action.yml
+++ b/packages/github-actions/actions/coverage-report/action.yml
@@ -52,7 +52,7 @@ runs:
 
     # Save coverage report as an artifact
     - if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ inputs.report-name }}
         path: "${{ inputs.report-path }}/${{ inputs.report-file }}"

--- a/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: "Make the PR"
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           const title = `${ context.payload.pull_request.title } - Merge \`trunk\` to \`develop\``;

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -11,12 +11,12 @@ runs:
   using: composite
   steps:
     # Checkout repository.
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         fetch-depth: 2
 
     # Set up PHP.
-    - uses: woocommerce/grow/prepare-php@actions-v3
+    - uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
       with:
         php-version: ${{ inputs.php-version }}
 

--- a/packages/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/github-actions/actions/prepare-extension-release/action.yml
@@ -58,7 +58,7 @@ runs:
         git push --set-upstream origin "${BRANCH_NAME}"
     - name: Create a pull request for the release
       id: prepare-release-pr
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           const action_path = '${{ github.action_path }}';

--- a/packages/github-actions/actions/prepare-node/action.yml
+++ b/packages/github-actions/actions/prepare-node/action.yml
@@ -29,7 +29,7 @@ runs:
   using: composite
   steps:
     # Setup node version and caching.
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}

--- a/packages/github-actions/actions/prepare-php/action.yml
+++ b/packages/github-actions/actions/prepare-php/action.yml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     # Set up PHP and tools.
-    - uses: shivammathur/setup-php@v2
+    - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       with:
         php-version: ${{ inputs.php-version }}
         coverage: ${{ inputs.coverage }}
@@ -50,7 +50,7 @@ runs:
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     # Set up Composer caching.
-    - uses: actions/cache@v5
+    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: ${{ steps.composer-cache-config.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/packages/github-actions/actions/publish-extension-dev-build/action.yml
+++ b/packages/github-actions/actions/publish-extension-dev-build/action.yml
@@ -23,13 +23,13 @@ runs:
   steps:
     # Get unreleased notes
     - id: unreleased-notes
-      uses: woocommerce/grow/get-release-notes@actions-v3
+      uses: woocommerce/grow/get-release-notes@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
       with:
         repo-token: ${{ github.token }}
         tag-template: "{version}"
 
     # Publish the build to GitHub
-    - uses: actions/github-script@v9
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         # The main action inputs are not accessible within the "script" input of actions/github-script.
         # So it needs to do forwarding.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

WooCommerce intends to enforce full-length commit SHA pinning for GitHub Actions across the organization. This pins remote action references in workflows and composite actions to the commits currently identified by their existing tags or branches, retaining those refs in comments. Immutable references reduce the risk that a moved or compromised upstream ref can silently change CI code and narrow the supply-chain compromise surface.

### Screenshots:

<!--- Optional --->

Not applicable; this changes workflow and composite action configuration only.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Re-run the action reference scanner in check mode and confirm zero unpinned remote action references remain.
2. Run `git diff --check`.
3. Parse every changed workflow and composite action file as YAML.

All three checks pass on this branch.

### Additional details:

<!--
Optional.

For changes related to a releasable package, please use the corresponding changelog labels, for example, `[actions] changelog: *` for the `github-actions` package, and likewise for the `jsdoc` and `tracking-jsdoc` packages.

Add the `changelog: none` label if no changelog entry is needed.
-->

No changelog is needed because this changes workflow/action configuration only and is not shipped to merchants.
