### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/github-action-publish-compat-checker.yml
+++ b/.github/workflows/github-action-publish-compat-checker.yml
@@ -11,6 +11,7 @@ jobs:
   deploy:
     name: Publish Compat Checker package
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/github-actions-create-release.yml
+++ b/.github/workflows/github-actions-create-release.yml
@@ -9,6 +9,7 @@ jobs:
   CreateRelease:
     name: Create release for github-actions package
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.event.pull_request.head.ref == 'release/actions' && github.event.review.state == 'approved' }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/github-actions-create-test-build.yml
+++ b/.github/workflows/github-actions-create-test-build.yml
@@ -8,6 +8,7 @@ jobs:
   CreateTestBuild:
     name: Create Test Build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/github-actions-delete-test-build.yml
+++ b/.github/workflows/github-actions-delete-test-build.yml
@@ -7,6 +7,7 @@ jobs:
   DeleteTestBuild:
     name: Delete Test Build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.ref_type == 'branch'
     steps:
       - name: Checkout repository

--- a/.github/workflows/github-actions-prepare-release.yml
+++ b/.github/workflows/github-actions-prepare-release.yml
@@ -9,6 +9,7 @@ jobs:
   CheckCreatedBranch:
     name: Check Created Branch
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check created release branch
         uses: actions/github-script@v9
@@ -24,6 +25,7 @@ jobs:
   PrepareRelease:
     name: Prepare Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository

--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -18,6 +18,7 @@ jobs:
   Setup:
     name: Setup and Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       release: ${{ steps.set-result.outputs.release }}
     steps:
@@ -65,6 +66,7 @@ jobs:
   UpdateTags:
     name: Create Release Build and Update Version Tags
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: Setup
     steps:
       - name: Resolve tag name
@@ -114,6 +116,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_run' }}
     needs: UpdateTags
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -20,6 +20,7 @@ jobs:
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -35,6 +36,7 @@ jobs:
   build-check:
     name: Build Check
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -50,6 +52,7 @@ jobs:
   test-prepare-node:
     name: "prepare-node (Node ${{ matrix.node-version }}, deps: ${{ matrix.install-deps }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +93,7 @@ jobs:
   test-prepare-php:
     name: "prepare-php (PHP ${{ matrix.php-version }}, deps: ${{ matrix.install-deps }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -130,6 +134,7 @@ jobs:
   test-prepare-mysql:
     name: prepare-mysql
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: ./packages/github-actions/actions/prepare-mysql
@@ -139,6 +144,7 @@ jobs:
   test-eslint-formatter:
     name: "eslint-annotation (eslint v${{ matrix.eslint-version }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -182,6 +188,7 @@ jobs:
   test-stylelint-formatter:
     name: "stylelint-annotation (stylelint v${{ matrix.stylelint-version }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -25,6 +25,7 @@ jobs:
   JSLintingCheck:
     name: Lint JavaScript
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/js-packages-create-release.yml
+++ b/.github/workflows/js-packages-create-release.yml
@@ -9,6 +9,7 @@ jobs:
   CreateRelease:
     name: Create release for JS package
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ (github.event.pull_request.head.ref == 'release/jsdoc' || github.event.pull_request.head.ref == 'release/tracking-jsdoc') && github.event.review.state == 'approved' }}
     steps:
       - name: Derive package config

--- a/.github/workflows/js-packages-prepare-release.yml
+++ b/.github/workflows/js-packages-prepare-release.yml
@@ -10,6 +10,7 @@ jobs:
   CheckCreatedBranch:
     name: Check Created Branch
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check created release branch
         uses: actions/github-script@v9
@@ -25,6 +26,7 @@ jobs:
   PrepareRelease:
     name: Prepare Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository

--- a/.github/workflows/js-packages-release.yml
+++ b/.github/workflows/js-packages-release.yml
@@ -18,6 +18,7 @@ jobs:
   Setup:
     name: Setup and Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       release: ${{ steps.set-result.outputs.release }}
     steps:
@@ -65,6 +66,7 @@ jobs:
   UpdateTags:
     name: Create Release Build and Update Version Tags
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: Setup
     steps:
       - name: Resolve tag name
@@ -113,6 +115,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_run' }}
     needs: UpdateTags
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -30,6 +30,7 @@ jobs:
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Add job timeouts so a hung run stops in minutes, not after six hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `github-action-publish-compat-checker.yml` / deploy | 0.1 min | 0.1 min | 5 |
| `github-actions-create-release.yml` / CreateRelease | 0.2 min | 0.2 min | 5 |
| `github-actions-create-test-build.yml` / CreateTestBuild | 0.3 min* | 0.4 min* | 5 |
| `github-actions-delete-test-build.yml` / DeleteTestBuild | 0.1 min | 0.1 min | 5 |
| `github-actions-prepare-release.yml` / CheckCreatedBranch | 0.1 min | 0.1 min | 5 |
| `github-actions-prepare-release.yml` / PrepareRelease | 0.3 min | 0.3 min | 5 |
| `github-actions-release.yml` / Setup | 0.1 min | 0.1 min | 5 |
| `github-actions-release.yml` / UpdateTags | 0.3 min | 0.3 min | 5 |
| `github-actions-release.yml` / MergeReleasePR | 0.1 min | 0.1 min | 5 |
| `github-actions-self-test.yml` / unit-test | 0.1 min | 0.2 min | 5 |
| `github-actions-self-test.yml` / build-check | 0.3 min | 0.3 min | 5 |
| `github-actions-self-test.yml` / test-prepare-node | 0.3 min | 0.5 min | 5 |
| `github-actions-self-test.yml` / test-prepare-php | 0.2 min | 0.4 min | 5 |
| `github-actions-self-test.yml` / test-prepare-mysql | 0.2 min | 0.2 min | 5 |
| `github-actions-self-test.yml` / test-eslint-formatter | 0.3 min | 0.4 min | 5 |
| `github-actions-self-test.yml` / test-stylelint-formatter | 0.3 min | 0.4 min | 5 |
| `js-linting.yml` / JSLintingCheck | 0.3 min | 0.3 min | 5 |
| `js-packages-create-release.yml` / CreateRelease | 0.1 min* | 0.2 min* | 5 |
| `js-packages-prepare-release.yml` / CheckCreatedBranch | 0.1 min* | 0.1 min* | 5 |
| `js-packages-prepare-release.yml` / PrepareRelease | 0.1 min* | 0.2 min* | 5 |
| `js-packages-release.yml` / Setup | 0.1 min* | 0.1 min* | 5 |
| `js-packages-release.yml` / UpdateTags | 0.2 min* | 0.2 min* | 5 |
| `js-packages-release.yml` / MergeReleasePR | 0.1 min* | 0.1 min* | 5 |
| `php-coding-standards.yml` / phpcs | 0.3 min | 0.4 min | 5 |

\* No successful run in the last 30 days. These durations come from the most recent successful runs (June and July 2026).

Part of TESTOPS-272
