### PR TITLE
Pin nested GitHub Action dependencies to full SHAs

### DIFF
--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: ./packages/github-actions/actions/prepare-node
         with:
           node-version-file: .nvmrc
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: ./packages/github-actions/actions/eslint-annotation
 
       # Turn off import/no-unresolved rule since this check doesn't install packages for all sub-packages.
       - name: Lint JavaScript and annotate linting errors

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -25,7 +25,7 @@ jobs:
   JSLintingCheck:
     name: Lint JavaScript
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -25,7 +25,7 @@ jobs:
   JSLintingCheck:
     name: Lint JavaScript
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -35,15 +35,8 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      # The checkout does not contain generated action bundles, so build them before using the formatter locally.
-      - name: Build actions
-        run: |
-          cd ./packages/github-actions
-          npm ci --ignore-scripts
-          npm run build
-
       - name: Prepare annotation formatter
-        uses: ./packages/github-actions/actions/eslint-annotation
+        uses: woocommerce/grow/eslint-annotation@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
 
       # Turn off import/no-unresolved rule since this check doesn't install packages for all sub-packages.
       - name: Lint JavaScript and annotate linting errors

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -36,7 +36,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Prepare annotation formatter
-        uses: ./packages/github-actions/actions/eslint-annotation
+        uses: woocommerce/grow/eslint-annotation@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3 test build
 
       # Turn off import/no-unresolved rule since this check doesn't install packages for all sub-packages.
       - name: Lint JavaScript and annotate linting errors

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -35,8 +35,15 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # The checkout does not contain generated action bundles, so build them before using the formatter locally.
+      - name: Build actions
+        run: |
+          cd ./packages/github-actions
+          npm ci --ignore-scripts
+          npm run build
+
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3 test build
+        uses: ./packages/github-actions/actions/eslint-annotation
 
       # Turn off import/no-unresolved rule since this check doesn't install packages for all sub-packages.
       - name: Lint JavaScript and annotate linting errors

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: ./packages/github-actions/actions/prepare-php
         with:
           php-version: 7.4
           tools: cs2pr

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         fetch-depth: 2
 
-    # Set up PHP.
+    # Deliberately mirrors prepare-php because a build cannot reference its own not-yet-published SHA.
     - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       with:
         php-version: ${{ inputs.php-version }}

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -16,9 +16,34 @@ runs:
         fetch-depth: 2
 
     # Set up PHP.
-    - uses: woocommerce/grow/prepare-php@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+    - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       with:
         php-version: ${{ inputs.php-version }}
+        coverage: none
+
+    # Log PHP and Composer information.
+    - shell: bash
+      run: |
+        php --version
+        composer --version
+
+    # Cache Composer packages.
+    - shell: bash
+      id: composer-cache-config
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: ${{ steps.composer-cache-config.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    # Install Composer dependencies.
+    - shell: bash
+      run: |
+        COMPOSER_VER=$(composer --version | awk '{ print $3 }')
+        composer install --prefer-dist --no-interaction `if [[ $COMPOSER_VER == 1.* ]]; then printf %s "--no-suggest"; fi`
+        echo "${PWD}/vendor/bin" >> "$GITHUB_PATH"
 
     #Log information
     - shell: bash


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Tracks WOOPRD-3718.

The organization-wide SHA-pinning audit found that Grow's workflows and the published `phpcs-diff` composite action still reached the older `actions-v3.0.4` build, whose own dependencies use mutable tags.

This change:

- uses checked-out local action sources in Grow's own workflows where the source tree contains everything required at runtime;
- keeps JavaScript linting pinned to the permanent `actions-v3.0.4` build of `eslint-annotation`, which has no nested `uses:` dependencies and already satisfies the SHA policy;
- replaces the `phpcs-diff` self-reference with equivalent PHP setup, Composer cache, and install steps whose actions use full commit SHAs; and
- preserves the existing PHPCS behavior while allowing the next Grow action build to contain no mutable nested action references.

The `phpcs-diff` setup intentionally mirrors `prepare-php`: an action build cannot reference its own not-yet-published SHA. A source comment calls out that maintenance relationship.

Some existing references to the `actions-v3.0.4` build remain where the target is a JavaScript action with no nested `uses:` dependencies, including `eslint-annotation` and `get-release-notes`. Those references already satisfy the pinning policy and are expected to lag by one action release. In particular, the checked-out source does not contain `eslintFormatter.cjs`; building every action bundle inside the lint job would generate `.mjs` files that the repository-wide ESLint command then scans, materially changing that job's input and runtime.

### Detailed test instructions:

1. From `packages/github-actions`, run `npm ci --ignore-scripts`.
2. Run `npm test` and confirm all 82 tests pass.
3. Run `npm run build` and confirm the generated formatter bundles are created successfully.
4. Parse `.github/workflows/js-linting.yml`, `.github/workflows/php-coding-standards.yml`, and `packages/github-actions/actions/phpcs-diff/action.yml` as YAML.
5. Confirm every remote `uses:` reference in the changed files uses a full 40-character commit SHA; local source actions remain local where their runtime files are present in the checkout.
6. Confirm the hosted JavaScript lint job completes within its original five-minute timeout.

### Follow-up after this PR merges:

Downstream repositories must not merge their nested-action remediation PRs while they reference the disposable test-build commit `a81d3fca0166a02a4c25953d250d80d3612db4b8`.

1. Run `release/actions` from Grow's updated `trunk` branch. The preparation workflow should open the `3.0.5` release PR.
2. Approve the release PR so the release workflows create `actions-v3.0.5`, build the standalone actions commit, and advance `actions-v3` and `actions-v3.0`.
3. Resolve the immutable release build SHA with `git rev-parse actions-v3.0.5` and recursively re-audit that commit. It should contain no mutable remote Action dependencies.
4. Update the 28 affected downstream repository PRs: replace all 138 references to the test-build SHA across 89 workflow files with the `actions-v3.0.5` build SHA and correct the trailing version comments.
5. Review Google Listings & Ads separately because its remediation also bridges removed v2 QIT actions while moving to the v3 action build.
6. Open a follow-up Grow PR to advance the compliant JavaScript self-references—including JavaScript linting—to `actions-v3.0.5`; `publish-extension-dev-build` will continue to lag one release by design.
7. Re-run the recursive dependency audit on the downstream PR heads, merge them, then re-audit active default branches before enabling organization-wide enforcement.
8. Close WOOPRD-3718 and the downstream Linear issues only after their post-merge audits pass.

*\*left by Biff (AI agent) on behalf of Darren*
