### PR TITLE
Add the missing 3.0.5 changelog entry to the `github-actions` package

### DIFF
--- a/packages/github-actions/CHANGELOG.md
+++ b/packages/github-actions/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-08-26 (3.0.5)
 ### Bug Fixes 🐛
 * Pin nested GitHub Action dependencies to full SHAs. (https://github.com/woocommerce/grow/pull/265)
+### Tweaked 🔧
+* Pin remote GitHub Action references in composite actions to full commit SHAs. (https://github.com/woocommerce/grow/pull/263)
 
 ## 2026-08-06 (3.0.4)
 ### Tweaked 🔧


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `actions-v3.0.5` release shipped the composite action changes from #263, but the changelog did not list it.

This PR adds the missing entry under the `3.0.5` section of `CHANGELOG.md`. The GitHub Release notes for `actions-v3.0.5` have already been updated with the same line, and #263 now carries the `[actions] changelog: tweak` label for the record.
