### PR TITLE
Tweak the action references in the `github-actions` package

### DIFF
--- a/packages/github-actions/actions/automerge-released-trunk/action.yml
+++ b/packages/github-actions/actions/automerge-released-trunk/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: "Merge the release to develop"
       shell: bash
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}

--- a/packages/github-actions/actions/branch-label/action.yml
+++ b/packages/github-actions/actions/branch-label/action.yml
@@ -11,4 +11,4 @@ runs:
         mkdir -p "$CONFIG_DIR"
         cp "${{ github.action_path }}/labeler.yml" "$CONFIG_DIR"
 
-    - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
+    - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0

--- a/packages/github-actions/actions/coverage-report/action.yml
+++ b/packages/github-actions/actions/coverage-report/action.yml
@@ -52,7 +52,7 @@ runs:
 
     # Save coverage report as an artifact
     - if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.report-name }}
         path: "${{ inputs.report-path }}/${{ inputs.report-file }}"

--- a/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
+++ b/packages/github-actions/actions/merge-trunk-develop-pr/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: "Make the PR"
       if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' }}
-      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const title = `${ context.payload.pull_request.title } - Merge \`trunk\` to \`develop\``;

--- a/packages/github-actions/actions/phpcs-diff/README.md
+++ b/packages/github-actions/actions/phpcs-diff/README.md
@@ -11,6 +11,8 @@ Install required packages: `dealerdirect/phpcodesniffer-composer-installer` and 
 
 - `composer require --dev dealerdirect/phpcodesniffer-composer-installer:^v0.7 exussum12/coverage-checker:^1.0`
 
+This action references a sibling action through GitHub's self repository syntax (`$/`), which is not available on GitHub Enterprise Server.
+
 ## Usage
 
 See [action.yml](action.yml)

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -15,35 +15,12 @@ runs:
       with:
         fetch-depth: 2
 
-    # Deliberately mirrors prepare-php because a build cannot reference its own not-yet-published SHA.
-    - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+    # Resolves to this repository at the commit that is running, so this sibling always
+    # matches the release it ships in. The path is relative to the repository root,
+    # which is the flattened layout of a release build rather than the source tree.
+    - uses: $/prepare-php
       with:
         php-version: ${{ inputs.php-version }}
-        coverage: none
-
-    # Log PHP and Composer information.
-    - shell: bash
-      run: |
-        php --version
-        composer --version
-
-    # Cache Composer packages.
-    - shell: bash
-      id: composer-cache-config
-      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
-      with:
-        path: ${{ steps.composer-cache-config.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
-
-    # Install Composer dependencies.
-    - shell: bash
-      run: |
-        COMPOSER_VER=$(composer --version | awk '{ print $3 }')
-        composer install --prefer-dist --no-interaction `if [[ $COMPOSER_VER == 1.* ]]; then printf %s "--no-suggest"; fi`
-        echo "${PWD}/vendor/bin" >> "$GITHUB_PATH"
 
     #Log information
     - shell: bash

--- a/packages/github-actions/actions/phpcs-diff/action.yml
+++ b/packages/github-actions/actions/phpcs-diff/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     # Checkout repository.
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         fetch-depth: 2
 

--- a/packages/github-actions/actions/prepare-extension-release/action.yml
+++ b/packages/github-actions/actions/prepare-extension-release/action.yml
@@ -58,7 +58,7 @@ runs:
         git push --set-upstream origin "${BRANCH_NAME}"
     - name: Create a pull request for the release
       id: prepare-release-pr
-      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const action_path = '${{ github.action_path }}';

--- a/packages/github-actions/actions/prepare-node/action.yml
+++ b/packages/github-actions/actions/prepare-node/action.yml
@@ -29,7 +29,7 @@ runs:
   using: composite
   steps:
     # Setup node version and caching.
-    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}

--- a/packages/github-actions/actions/prepare-php/action.yml
+++ b/packages/github-actions/actions/prepare-php/action.yml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     # Set up PHP and tools.
-    - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+    - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ inputs.php-version }}
         coverage: ${{ inputs.coverage }}
@@ -50,7 +50,7 @@ runs:
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     # Set up Composer caching.
-    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ steps.composer-cache-config.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/packages/github-actions/actions/publish-extension-dev-build/README.md
+++ b/packages/github-actions/actions/publish-extension-dev-build/README.md
@@ -4,6 +4,10 @@ This action provides the following functionality for GitHub Actions users:
 
 - Publish or update the extension development build via a pre-release on GitHub.
 
+## Prerequisites
+
+This action references a sibling action through GitHub's self repository syntax (`$/`), which is not available on GitHub Enterprise Server.
+
 ## Usage
 
 See [action.yml](action.yml)

--- a/packages/github-actions/actions/publish-extension-dev-build/action.yml
+++ b/packages/github-actions/actions/publish-extension-dev-build/action.yml
@@ -32,7 +32,7 @@ runs:
         tag-template: "{version}"
 
     # Publish the build to GitHub
-    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         # The main action inputs are not accessible within the "script" input of actions/github-script.
         # So it needs to do forwarding.

--- a/packages/github-actions/actions/publish-extension-dev-build/action.yml
+++ b/packages/github-actions/actions/publish-extension-dev-build/action.yml
@@ -23,7 +23,10 @@ runs:
   steps:
     # Get unreleased notes
     - id: unreleased-notes
-      uses: woocommerce/grow/get-release-notes@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+      # Resolves to this repository at the commit that is running, so this sibling always
+      # matches the release it ships in. The path is relative to the repository root,
+      # which is the flattened layout of a release build rather than the source tree.
+      uses: $/get-release-notes
       with:
         repo-token: ${{ github.token }}
         tag-template: "{version}"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`publish-extension-dev-build` pinned a sibling action to a commit SHA of this repository, and `phpcs-diff` carried an inline copy of `prepare-php`. Both now use the self repository syntax. The comments next to the third-party pins recorded only a major version, and now name the exact release.

**Sibling references now use the self repository syntax.**

`$/` resolves to this repository at the commit that is running, and it carries no ref of its own, so a sibling always matches whatever ref the caller used. Version skew is removed rather than postponed, because a self-reference has no ref that can go stale.

The current release shows that skew concretely. The `actions-v3.0.5` build of `publish-extension-dev-build` calls `get-release-notes` from `actions-v3.0.4`, because the pin was written before `actions-v3.0.5` existed and a build cannot pin the release it is about to become. Those two builds happen to be identical, so nothing misbehaves today, but the same gap reopens at every release and matters as soon as a sibling changes.

`phpcs-diff` previously mirrored the body of `prepare-php` inline for that same reason. The constraint holds for a SHA but not for `$/`, so the mirror is no longer needed, and the duplicated setup is removed. Calling `prepare-php` with only `php-version` restores the shape that shipped from `actions-v3.0.0` through `actions-v3.0.4`, so this is not a new configuration.

This is also compatible with the organization policy that requires actions to be pinned to a full-length commit SHA. That policy checks the whole dependency tree rather than only the workflow file, so what a shipped action references internally matters to every consumer. A self-reference carries no ref to pin and is accepted the same way a local `./` reference is.

One trade-off is worth recording: `$/` is not available on GitHub Enterprise Server. Every known consumer of this package runs on github.com, where it is generally available. Both action READMEs now state this.

**Version comments now name the exact release.**

The SHAs on these lines are unchanged. Only the comments:

```
actions/checkout        # v6  ->  # v6.1.0
actions/setup-node      # v6  ->  # v6.5.0
actions/github-script   # v9  ->  # v9.0.0
actions/upload-artifact # v7  ->  # v7.0.1
actions/labeler         # v6  ->  # v6.2.0
actions/cache           # v5  ->  # v5.1.0
shivammathur/setup-php  # v2  ->  # 2.37.2
```

`shivammathur/setup-php` publishes unprefixed tags, so its comment has no leading `v`.