### PR TITLE
Support building a single action in the `github-actions` package

### DIFF
--- a/packages/github-actions/rollup.config.js
+++ b/packages/github-actions/rollup.config.js
@@ -4,7 +4,7 @@
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-export default [
+const configs = [
 	{
 		input: './actions/eslint-annotation/src/eslintFormatter.js',
 		output: {
@@ -101,3 +101,28 @@ export default [
 		],
 	},
 ];
+
+const actionName = ( { input } ) => input.split( '/' )[ 2 ];
+
+// `--configAction` narrows the build to one action, so a workflow that needs a
+// single bundle does not write the others into paths that a later step reads.
+// Example: npm run build -- --configAction=eslint-annotation
+export default ( cliArgs ) => {
+	if ( ! ( 'configAction' in cliArgs ) ) {
+		return configs;
+	}
+
+	const selected = configs.filter(
+		( config ) => actionName( config ) === cliArgs.configAction
+	);
+
+	if ( ! selected.length ) {
+		const names = [ ...new Set( configs.map( actionName ) ) ];
+		throw new Error(
+			`No rollup configuration matches the action "${ cliArgs.configAction }". ` +
+				`Available: ${ names.join( ', ' ) }.`
+		);
+	}
+
+	return selected;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`rollup.config.js` exported one array covering every action, so `npm run build` always writes all eight bundles. A caller that needs one of them has no way to ask for just that one.

The default export is now a function. Passing `--configAction` narrows the build to a single action, and leaving it out keeps the existing behaviour, so the release build and every current caller are unaffected.

```
npm run build                                       # all bundles
npm run build -- --configAction=eslint-annotation   # only that one
```

An unknown name fails rather than building nothing, because an empty selection is almost always a typo. The message lists the names that can be built, derived from the config so it cannot drift.

Nothing here passes the option yet. A separate pull request moves the workflows that need a single bundle onto it, and this one lands first so that there is something for them to call. Three existing callers also build all eight bundles while using one, in `github-actions-prepare-release.yml` and in two jobs of `github-actions-self-test.yml`, and they can move over later.

A workflow that needs only the eslint formatter currently writes all of that into the action directories, and anything that reads those paths afterwards pays for it. The JavaScript lint is the clearest case: `eslint --ext .js,.mjs .` parses the generated bundles, which takes it from roughly one second to over two minutes. Building one action keeps those paths clean without any ignore rules.

### Detailed test instructions:

1. `npm run build` to confirm the default still builds every action.
2. `rm -f actions/*/*.mjs actions/*/*.cjs` and `npm run build -- --configAction=eslint-annotation` to confirm a narrowed build writes only the requested bundle.
3. `npm run build -- --configAction=no-such-action` to confirm an unknown action fails with a clear message.
