### PR TITLE
Build this repository's own actions instead of pinning a release

### DIFF
--- a/.github/workflows/github-action-publish-compat-checker.yml
+++ b/.github/workflows/github-action-publish-compat-checker.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Deploy
-      uses: s0/git-publish-subdir-action@92faf786f11dfa44fc366ac3eb274d193ca1af7e # v.2.6.0
+      uses: s0/git-publish-subdir-action@92faf786f11dfa44fc366ac3eb274d193ca1af7e # v2.6.0
       env:
         REPO: self
         BRANCH: compat-checker

--- a/.github/workflows/github-actions-create-release.yml
+++ b/.github/workflows/github-actions-create-release.yml
@@ -13,10 +13,10 @@ jobs:
     if: ${{ github.event.pull_request.head.ref == 'release/actions' && github.event.review.state == 'approved' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Create release
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const workspace = '${{ github.workspace }}';
@@ -31,7 +31,7 @@ jobs:
             } );
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release
           path: /tmp/release.json

--- a/.github/workflows/github-actions-create-test-build.yml
+++ b/.github/workflows/github-actions-create-test-build.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare node
         uses: ./packages/github-actions/actions/prepare-node

--- a/.github/workflows/github-actions-delete-test-build.yml
+++ b/.github/workflows/github-actions-delete-test-build.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.ref_type == 'branch'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: trunk
 

--- a/.github/workflows/github-actions-prepare-release.yml
+++ b/.github/workflows/github-actions-prepare-release.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check created release branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             if ( ! context.payload.created ) {
@@ -29,7 +29,7 @@ jobs:
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare node
         uses: ./packages/github-actions/actions/prepare-node
@@ -87,7 +87,7 @@ jobs:
           git push
 
       - name: Create a pull request for release
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const workspace = '${{ github.workspace }}';

--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -23,7 +23,7 @@ jobs:
       release: ${{ steps.set-result.outputs.release }}
     steps:
       - name: Check tag name or workflow_run conclusion
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { payload, eventName } = context;
@@ -41,7 +41,7 @@ jobs:
       - name: Get release artifact
         id: set-result
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require( 'fs' );
@@ -79,7 +79,7 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ steps.resolve-tag.outputs.tag_name }}
 

--- a/.github/workflows/github-actions-self-test.yml
+++ b/.github/workflows/github-actions-self-test.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: .nvmrc
       - name: Install dependencies
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: .nvmrc
       - name: Install dependencies
@@ -64,7 +64,7 @@ jobs:
             install-deps: 'yes'
             ignore-scripts: 'no'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./packages/github-actions/actions/prepare-node
         with:
           node-version: ${{ matrix.node-version }}
@@ -103,7 +103,7 @@ jobs:
           - php-version: '8.2'
             install-deps: 'yes'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Create minimal Composer project for install test
         if: matrix.install-deps == 'yes'
         run: |
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./packages/github-actions/actions/prepare-mysql
       - name: Verify MySQL connection
         run: mysql -u root -proot -e "SELECT 1;"
@@ -150,8 +150,8 @@ jobs:
       matrix:
         eslint-version: ['8', '9']
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
       - name: Build the formatter
@@ -194,8 +194,8 @@ jobs:
       matrix:
         stylelint-version: ['15', '16', '17']
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
       - name: Build the formatter

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare node
         uses: ./packages/github-actions/actions/prepare-node

--- a/.github/workflows/js-linting.yml
+++ b/.github/workflows/js-linting.yml
@@ -34,9 +34,20 @@ jobs:
         uses: ./packages/github-actions/actions/prepare-node
         with:
           node-version-file: .nvmrc
+          cache-dependency-path: |
+            ./package-lock.json
+            ./packages/github-actions/package-lock.json
+
+      # Bundled entry points are not in the checkout. Only the formatter is built
+      # because the other bundles are large and the lint below would parse them.
+      - name: Build the annotation formatter
+        working-directory: packages/github-actions
+        run: |
+          npm ci --ignore-scripts
+          npm run build -- --configAction=eslint-annotation
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: ./packages/github-actions/actions/eslint-annotation
 
       # Turn off import/no-unresolved rule since this check doesn't install packages for all sub-packages.
       - name: Lint JavaScript and annotate linting errors

--- a/.github/workflows/js-packages-create-release.yml
+++ b/.github/workflows/js-packages-create-release.yml
@@ -24,10 +24,10 @@ jobs:
           echo "tag-prefix=${TAG_PREFIX}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Create release
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const workspace = '${{ github.workspace }}';
@@ -42,7 +42,7 @@ jobs:
             } );
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release
           path: /tmp/release.json

--- a/.github/workflows/js-packages-prepare-release.yml
+++ b/.github/workflows/js-packages-prepare-release.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check created release branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             if ( ! context.payload.created ) {
@@ -30,7 +30,7 @@ jobs:
     needs: CheckCreatedBranch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Derive package config
         id: config
@@ -109,7 +109,7 @@ jobs:
           git push
 
       - name: Create a pull request for release
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const workspace = '${{ github.workspace }}';

--- a/.github/workflows/js-packages-prepare-release.yml
+++ b/.github/workflows/js-packages-prepare-release.yml
@@ -50,9 +50,24 @@ jobs:
           echo "config-path=${CONFIG_PATH}" >> $GITHUB_OUTPUT
           echo "has-lock-file=${HAS_LOCK_FILE}" >> $GITHUB_OUTPUT
 
+      - name: Prepare node
+        uses: ./packages/github-actions/actions/prepare-node
+        with:
+          node-version: 24
+          cache-dependency-path: ./packages/github-actions/package-lock.json
+          install-deps: "no"
+
+      # The checkout carries no bundled entry points, so this action has to be
+      # built before it can run from the source tree.
+      - name: Build the release notes action
+        working-directory: packages/github-actions
+        run: |
+          npm ci --ignore-scripts
+          npm run build -- --configAction=get-release-notes
+
       - name: Get release notes
         id: get-notes
-        uses: woocommerce/grow/get-release-notes@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: ./packages/github-actions/actions/get-release-notes
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           package-dir: ${{ steps.config.outputs.package-dir }}

--- a/.github/workflows/js-packages-release.yml
+++ b/.github/workflows/js-packages-release.yml
@@ -23,7 +23,7 @@ jobs:
       release: ${{ steps.set-result.outputs.release }}
     steps:
       - name: Check tag name or workflow_run conclusion
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { payload, eventName } = context;
@@ -41,7 +41,7 @@ jobs:
       - name: Get release artifact
         id: set-result
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require( 'fs' );
@@ -88,7 +88,7 @@ jobs:
           echo "package-dir=${PACKAGE_DIR}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ steps.resolve-tag.outputs.tag_name }}
 

--- a/.github/workflows/js-packages-release.yml
+++ b/.github/workflows/js-packages-release.yml
@@ -92,6 +92,13 @@ jobs:
         with:
           ref: ${{ steps.resolve-tag.outputs.tag_name }}
 
+      - name: Prepare node
+        uses: ./packages/github-actions/actions/prepare-node
+        with:
+          node-version: 24
+          cache-dependency-path: ./packages/github-actions/package-lock.json
+          install-deps: "no"
+
       - name: Create and commit release build
         id: commit-build
         run: |
@@ -103,8 +110,20 @@ jobs:
 
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
+      # The build above leaves the flattened package in place of the checkout. The
+      # whole package comes back, not just the action, because building it needs
+      # the package manifest and the rollup config.
+      - name: Restore the package
+        run: git checkout HEAD^ -- ./packages/github-actions
+
+      - name: Build the version tags action
+        working-directory: packages/github-actions
+        run: |
+          npm ci --ignore-scripts
+          npm run build -- --configAction=update-version-tags
+
       - name: Update version tags
-        uses: woocommerce/grow/update-version-tags@3a4249a1fc7e39a987d213e578cbcf32abd55980 # actions-v3
+        uses: ./packages/github-actions/actions/update-version-tags
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ steps.commit-build.outputs.sha }}

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare PHP
         uses: ./packages/github-actions/actions/prepare-php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Three workflows referenced actions published from this repository by pinned commit SHA, which meant every release of the `github-actions` package left them one release behind until someone remembered to bump them by hand. They all now build the action they need from the checkout and reference it by path, so there is no version to maintain.

| Workflow | Action | How it is reached now |
| --- | --- | --- |
| `js-linting.yml` | `eslint-annotation` | built, then `./packages/github-actions/actions/eslint-annotation` |
| `js-packages-prepare-release.yml` | `get-release-notes` | built, then `./packages/github-actions/actions/get-release-notes` |
| `js-packages-release.yml` | `update-version-tags` | restored, built, then `./packages/github-actions/actions/update-version-tags` |

**Only the needed action is built.** A full build also writes the other bundles into the action directories. In the lint workflow, that matters a great deal, because `eslint --ext .js,.mjs .` then parses them, which makes the job unreasonably slow. The narrowed build depends on the `--configAction` option, which a separate pull request adds to the package's rollup config and which needs to land first.

**The release workflow needs the package back before it can build it.** The release build replaces the checkout with the flattened package, so `packages/github-actions` is gone by the time the version tags step runs. The whole package is restored from the previous commit, not just the action, because building it needs the package manifest and the rollup config. The create test build workflow recovers it the same way, but only the actions directory, because it does not build anything.

**Version comments now name the exact release.** No SHA changed, only the comment beside it, so `# v6` reads `# v6.1.0` and so on across all twelve workflows. The comment on `s0/git-publish-subdir-action` also carried a stray period and now matches the real tag name, `v2.6.0`.
